### PR TITLE
Filter by Entity State [Resolves #1]

### DIFF
--- a/tests/test_label_generators.py
+++ b/tests/test_label_generators.py
@@ -1,5 +1,4 @@
 from architect.label_generators import BinaryLabelGenerator
-from architect.state_table_generators import StateFilter
 import testing.postgresql
 from sqlalchemy import create_engine
 from datetime import date, timedelta
@@ -21,15 +20,6 @@ events_data = [
 ]
 
 
-state_data = [
-    # entity id, as_of_time, state_one, state_two
-    [1, date(2014, 9, 30), True, False],
-    [2, date(2014, 9, 30), True, True],
-    [3, date(2014, 9, 30), False, True],
-    [4, date(2014, 9, 30), True, False],
-]
-
-
 def create_events(engine):
     engine.execute(
         'create table events (entity_id int, outcome_date date, outcome bool)'
@@ -41,22 +31,7 @@ def create_events(engine):
         )
 
 
-def create_sparse_state_table(engine):
-    engine.execute('''create table sparse_states (
-        entity_id int,
-        as_of_time timestamp,
-        state_one bool,
-        state_two bool
-    )''')
-
-    for row in state_data:
-        engine.execute(
-            'insert into sparse_states values (%s, %s, %s, %s)',
-            row
-        )
-
-
-def test_training_label_generation_no_state_table():
+def test_training_label_generation():
     with testing.postgresql.Postgresql() as postgresql:
         engine = create_engine(postgresql.url())
         create_events(engine)
@@ -83,45 +58,6 @@ def test_training_label_generation_no_state_table():
             # entity_id, as_of_date, label_window, name, type, label
             (1, date(2014, 9, 30), timedelta(180), 'outcome', 'binary', False),
             (3, date(2014, 9, 30), timedelta(180), 'outcome', 'binary', True),
-            (4, date(2014, 9, 30), timedelta(180), 'outcome', 'binary', False),
-        ]
-
-        assert records == expected
-
-
-def test_training_label_generation_with_state_table():
-    with testing.postgresql.Postgresql() as postgresql:
-        engine = create_engine(postgresql.url())
-        create_events(engine)
-        create_sparse_state_table(engine)
-
-        labels_table_name = 'labels'
-
-        label_generator = BinaryLabelGenerator(
-            events_table='events',
-            db_engine=engine,
-        )
-
-        state_filter = StateFilter(
-            sparse_state_table='sparse_states',
-            filter_logic='state_one and not state_two'
-        )
-        label_generator._create_labels_table(labels_table_name)
-        label_generator.generate(
-            start_date='2014-09-30',
-            label_window='6month',
-            labels_table=labels_table_name,
-            state_filter=state_filter
-        )
-
-        result = engine.execute(
-            'select * from {} order by entity_id, as_of_date'.format(labels_table_name)
-        )
-        records = [row for row in result]
-
-        expected = [
-            # entity_id, as_of_date, label_window, name, type, label
-            (1, date(2014, 9, 30), timedelta(180), 'outcome', 'binary', False),
             (4, date(2014, 9, 30), timedelta(180), 'outcome', 'binary', False),
         ]
 

--- a/tests/test_planner_builders.py
+++ b/tests/test_planner_builders.py
@@ -1,5 +1,5 @@
 from architect import Planner, builders
-from tests.utils import create_features_and_labels_schemas
+from tests.utils import create_schemas
 from tests.utils import create_entity_date_df
 from tests.utils import convert_string_column_to_date
 from tests.utils import NamedTempFile
@@ -16,6 +16,39 @@ from mock import Mock
 
 
 # make some fake features data
+
+states = [
+    [0, '2016-02-01', False, True],
+    [0, '2016-02-01', False, True],
+    [0, '2016-03-01', False, True],
+    [0, '2016-04-01', False, True],
+    [0, '2016-05-01', False, True],
+    [1, '2016-01-01', True, False],
+    [1, '2016-02-01', True, False],
+    [1, '2016-03-01', True, False],
+    [1, '2016-04-01', True, False],
+    [1, '2016-05-01', True, False],
+    [2, '2016-01-01', True, False],
+    [2, '2016-02-01', True, True],
+    [2, '2016-03-01', True, False],
+    [2, '2016-04-01', True, True],
+    [2, '2016-05-01', True, False],
+    [3, '2016-01-01', False, True],
+    [3, '2016-02-01', True, True],
+    [3, '2016-03-01', False, True],
+    [3, '2016-04-01', True, True],
+    [3, '2016-05-01', False, True],
+    [4, '2016-01-01', True, True],
+    [4, '2016-02-01', True, True],
+    [4, '2016-03-01', True, True],
+    [4, '2016-04-01', True, True],
+    [4, '2016-05-01', True, True],
+    [5, '2016-01-01', False, False],
+    [5, '2016-02-01', False, False],
+    [5, '2016-03-01', False, False],
+    [5, '2016-04-01', False, False],
+    [5, '2016-05-01', False, False]
+]
 
 features0 = [
     [0, '2016-01-01', 2, 0],
@@ -36,7 +69,11 @@ features1 = [
     [0, '2016-03-01', 3, 3],
     [1, '2016-03-01', 3, 4],
     [2, '2016-03-01', 3, 3],
-    [3, '2016-03-01', 3, 4]
+    [3, '2016-03-01', 3, 4],
+    [3, '2016-03-01', 3, 4],
+    [0, '2016-03-01', 3, 3],
+    [4, '2016-03-01', 1, 4],
+    [5, '2016-03-01', 2, 4]
 ] 
 
 features_tables = [features0, features1]
@@ -83,6 +120,26 @@ labels = [
     [3, '2016-03-01', '1 month', 'ems',     'binary', 0],
     [3, '2016-04-01', '1 month', 'ems',     'binary', 1],
     [3, '2016-05-01', '1 month', 'ems',     'binary', 0],
+    [4, '2016-01-01', '1 month', 'booking', 'binary', 1],
+    [4, '2016-02-01', '1 month', 'booking', 'binary', 0],
+    [4, '2016-03-01', '1 month', 'booking', 'binary', 0],
+    [4, '2016-04-01', '1 month', 'booking', 'binary', 0],
+    [4, '2016-05-01', '1 month', 'booking', 'binary', 0],
+    [4, '2016-01-01', '1 month', 'ems',     'binary', 0],
+    [4, '2016-02-01', '1 month', 'ems',     'binary', 1],
+    [4, '2016-03-01', '1 month', 'ems',     'binary', 0],
+    [4, '2016-04-01', '1 month', 'ems',     'binary', 1],
+    [4, '2016-05-01', '1 month', 'ems',     'binary', 1],
+    [5, '2016-01-01', '1 month', 'booking', 'binary', 1],
+    [5, '2016-02-01', '1 month', 'booking', 'binary', 0],
+    [5, '2016-03-01', '1 month', 'booking', 'binary', 0],
+    [5, '2016-04-01', '1 month', 'booking', 'binary', 0],
+    [5, '2016-05-01', '1 month', 'booking', 'binary', 0],
+    [5, '2016-01-01', '1 month', 'ems',     'binary', 0],
+    [5, '2016-02-01', '1 month', 'ems',     'binary', 1],
+    [5, '2016-03-01', '1 month', 'ems',     'binary', 0],
+    [5, '2016-04-01', '1 month', 'ems',     'binary', 0],
+    [5, '2016-05-01', '1 month', 'ems',     'binary', 0],
     [0, '2016-02-01', '3 month', 'booking', 'binary', 0],
     [0, '2016-03-01', '3 month', 'booking', 'binary', 0],
     [0, '2016-04-01', '3 month', 'booking', 'binary', 0],
@@ -121,7 +178,28 @@ labels = [
     [3, '2016-02-01', '3 month', 'ems',     'binary', 0],
     [3, '2016-03-01', '3 month', 'ems',     'binary', 0],
     [3, '2016-04-01', '3 month', 'ems',     'binary', 1],
-    [3, '2016-05-01', '3 month', 'ems',     'binary', 0]
+    [3, '2016-05-01', '3 month', 'ems',     'binary', 0],
+    [3, '2016-05-01', '3 month', 'ems',     'binary', 0],
+    [4, '2016-01-01', '3 month', 'booking', 'binary', 0],
+    [4, '2016-02-01', '3 month', 'booking', 'binary', 0],
+    [4, '2016-03-01', '3 month', 'booking', 'binary', 1],
+    [4, '2016-04-01', '3 month', 'booking', 'binary', 0],
+    [4, '2016-05-01', '3 month', 'booking', 'binary', 1],
+    [4, '2016-01-01', '3 month', 'ems',     'binary', 0],
+    [4, '2016-02-01', '3 month', 'ems',     'binary', 0],
+    [4, '2016-03-01', '3 month', 'ems',     'binary', 0],
+    [4, '2016-04-01', '3 month', 'ems',     'binary', 0],
+    [4, '2016-05-01', '3 month', 'ems',     'binary', 1],
+    [5, '2016-01-01', '3 month', 'booking', 'binary', 0],
+    [5, '2016-02-01', '3 month', 'booking', 'binary', 0],
+    [5, '2016-03-01', '3 month', 'booking', 'binary', 1],
+    [5, '2016-04-01', '3 month', 'booking', 'binary', 0],
+    [5, '2016-05-01', '3 month', 'booking', 'binary', 1],
+    [5, '2016-01-01', '3 month', 'ems',     'binary', 0],
+    [5, '2016-02-01', '3 month', 'ems',     'binary', 0],
+    [5, '2016-03-01', '3 month', 'ems',     'binary', 0],
+    [5, '2016-04-01', '3 month', 'ems',     'binary', 1],
+    [5, '2016-05-01', '3 month', 'ems',     'binary', 0]
 ]
 
 label_name = 'booking'
@@ -131,77 +209,9 @@ db_config = {
     'features_schema_name': 'features',
     'labels_schema_name': 'labels',
     'labels_table_name': 'labels',
+    'sparse_state_table_name': 'staging.sparse_states',
 }
 
-def test_build_labels_query():
-    """ Test the generate_labels_query function by checking whether the query
-    produces the correct labels
-    """
-    # set up labeling config variables
-    dates = [datetime.datetime(2016, 1, 1, 0, 0),
-             datetime.datetime(2016, 2, 1, 0, 0)]
-
-    with testing.postgresql.Postgresql() as postgresql:
-        # create an engine and generate a table with fake feature data
-        engine = create_engine(postgresql.url())
-        create_features_and_labels_schemas(engine, features_tables, labels)
-
-    # make a dataframe of labels to test against
-    labels_df = pd.DataFrame(
-        labels,
-        columns = [
-            'entity_id',
-            'as_of_date',
-            'label_window',
-            'label_name',
-            'label_type',
-            'label'
-        ]
-    )
-    labels_df['as_of_date'] = convert_string_column_to_date(labels_df['as_of_date'])
-
-    # create an engine and generate a table with fake feature data
-    with testing.postgresql.Postgresql() as postgresql:
-        engine = create_engine(postgresql.url())
-        create_features_and_labels_schemas(engine, features_tables, labels)
-        with TemporaryDirectory() as temp_dir:
-            planner = Planner(
-                beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
-                label_names = ['booking'],
-                label_types = ['binary'],
-                db_config = db_config,
-                matrix_directory = temp_dir,
-                user_metadata = {},
-                engine = engine
-            )       
-
-            # get the queries and test them
-            for date in dates:
-                date = date.date()
-                df = labels_df[labels_df['label_name'] == label_name]
-                df = df[labels_df['label_type'] == label_type]
-                df = df[labels_df['label_window'] == '1 month']
-                print(date)
-                df = df[labels_df['as_of_date'] == date]
-                df = df[['entity_id', 'as_of_date', 'label']]
-                df = df.rename(
-                    columns = {
-                        "entity_id": "entity_id",
-                        "as_of_date": "as_of_date",
-                        "label": label_name
-                    }
-                )
-                df = df.reset_index(drop = True)
-                query = planner.builder.build_labels_query(
-                    as_of_times=[date],
-                    label_type=label_type,
-                    label_name=label_name,
-                    final_column=', label as {}'.format(label_name),
-                    label_window='1 month'
-                )
-                result = pd.read_sql(query, engine)
-                test = (result == df)
-                assert(test.all().all())
 
 def test_write_to_csv():
     """ Test the write_to_csv function by checking whether the csv contains the
@@ -210,13 +220,19 @@ def test_write_to_csv():
     with testing.postgresql.Postgresql() as postgresql:
         # create an engine and generate a table with fake feature data
         engine = create_engine(postgresql.url())
-        create_features_and_labels_schemas(engine, features_tables, labels)
+        create_schemas(
+            engine=engine,
+            features_tables=features_tables,
+            labels=labels,
+            states=states
+        )
 
         with TemporaryDirectory() as temp_dir:
             planner = Planner(
                 beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
                 label_names = ['booking'],
                 label_types = ['binary'],
+                states = ['state_one AND state_two'],
                 db_config = db_config,
                 matrix_directory = temp_dir,
                 user_metadata = {},
@@ -249,24 +265,32 @@ def test_make_entity_date_table():
 
     # make a dataframe of entity ids and dates to test against
     ids_dates = create_entity_date_df(
-        dates,
-        labels,
-        dates,
-        'booking',
-        'binary',
-        '1 month'
+        labels=labels,
+        states=states,
+        as_of_dates=dates,
+        state_one=True,
+        state_two=True,
+        label_name='booking',
+        label_type='binary',
+        label_window='1 month'
     )
 
     with testing.postgresql.Postgresql() as postgresql:
         # create an engine and generate a table with fake feature data
         engine = create_engine(postgresql.url())
-        create_features_and_labels_schemas(engine, features_tables, labels)
+        create_schemas(
+            engine=engine,
+            features_tables=features_tables,
+            labels=labels,
+            states=states
+        )
 
         with TemporaryDirectory() as temp_dir:
             planner = Planner(
                 beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
                 label_names = ['booking'],
                 label_types = ['binary'],
+                states = ['state_one AND state_two'],
                 db_config = db_config,
                 matrix_directory = temp_dir,
                 user_metadata = {},
@@ -280,7 +304,7 @@ def test_make_entity_date_table():
                 as_of_times=dates,
                 label_type='binary',
                 label_name='booking',
-                feature_table_names=['features0', 'features1'],
+                state='state_one AND state_two',
                 matrix_uuid='my_uuid',
                 matrix_type='train',
                 label_window='1 month'
@@ -304,20 +328,20 @@ def test_make_entity_date_table():
             print(test)
             assert(test.all().all())
 
-def test_build_outer_join_query():
-    """ 
-    """
+def test_write_features_data():
     dates = [datetime.datetime(2016, 1, 1, 0, 0),
              datetime.datetime(2016, 2, 1, 0, 0)]
 
     # make dataframe for entity ids and dates
     ids_dates = create_entity_date_df(
-        dates,
-        labels,
-        dates,
-        'booking',
-        'binary',
-        '1 month'
+        labels=labels,
+        states=states,
+        as_of_dates=dates,
+        state_one=True,
+        state_two=True,
+        label_name='booking',
+        label_type='binary',
+        label_window='1 month'
     )
 
     features = [['f1', 'f2'], ['f3', 'f4']]
@@ -341,17 +365,24 @@ def test_build_outer_join_query():
     # create an engine and generate a table with fake feature data
     with testing.postgresql.Postgresql() as postgresql:
         engine = create_engine(postgresql.url())
-        create_features_and_labels_schemas(engine, features_tables, labels)
+        create_schemas(
+            engine=engine,
+            features_tables=features_tables,
+            labels=labels,
+            states=states
+        )
 
         with TemporaryDirectory() as temp_dir:
             planner = Planner(
                 beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
                 label_names = ['booking'],
                 label_types = ['binary'],
+                states = ['state_one AND state_two'],
                 db_config = db_config,
                 matrix_directory = temp_dir,
                 user_metadata = {},
-                engine = engine
+                engine = engine,
+                builder_class=builders.LowMemoryCSVBuilder
             )
 
             # make the entity-date table
@@ -359,27 +390,110 @@ def test_build_outer_join_query():
                 as_of_times=dates,
                 label_type='binary',
                 label_name='booking',
-                feature_table_names=['features0', 'features1'],
+                state = 'state_one AND state_two',
                 matrix_type='train',
                 matrix_uuid='my_uuid',
                 label_window='1 month'
             )
 
+            feature_dictionary = dict(
+                ('features{}'.format(i), feature_list) for i, feature_list in enumerate(features)
+            )
+
+            print(feature_dictionary)
+            features_csv_names = planner.builder.write_features_data(
+                as_of_times=dates,
+                feature_dictionary=feature_dictionary,
+                entity_date_table_name=entity_date_table_name,
+                matrix_uuid='my_uuid'
+            )
+
             # get the queries and test them
-            for table_number, df in enumerate(features_dfs):
-                table_name = 'features{}'.format(table_number)
+            for feature_csv_name, df in zip(sorted(features_csv_names), features_dfs):
                 df = df.fillna(0)
-                query = planner.builder.build_outer_join_query(
-                    as_of_times = dates,
-                    right_table_name = 'features.{}'.format(table_name),
-                    entity_date_table_name = 'features.{}'.format(entity_date_table_name),
-                    right_column_selections = planner.builder._format_imputations(
-                        features[table_number]
-                    )
-                )
-                result = pd.read_sql(query, engine)
+                df = df.reset_index()
+
+                result = pd.read_csv(feature_csv_name).reset_index()
+                result['as_of_date'] = convert_string_column_to_date(result['as_of_date'])
                 test = (result == df)
                 assert(test.all().all())
+
+
+def test_write_labels_data():
+    """ Test the write_labels_data function by checking whether the query
+    produces the correct labels
+    """
+    # set up labeling config variables
+    dates = [datetime.datetime(2016, 1, 1, 0, 0),
+             datetime.datetime(2016, 2, 1, 0, 0)]
+
+
+    # make a dataframe of labels to test against
+    labels_df = pd.DataFrame(
+        labels,
+        columns = [
+            'entity_id',
+            'as_of_date',
+            'label_window',
+            'label_name',
+            'label_type',
+            'label'
+        ]
+    )
+
+    labels_df['as_of_date'] = convert_string_column_to_date(labels_df['as_of_date'])
+    labels_df.set_index(['entity_id', 'as_of_date'])
+
+    # create an engine and generate a table with fake feature data
+    with testing.postgresql.Postgresql() as postgresql:
+        engine = create_engine(postgresql.url())
+        create_schemas(
+            engine,
+            features_tables,
+            labels,
+            states
+        )
+        with TemporaryDirectory() as temp_dir:
+            planner = Planner(
+                beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
+                label_names = ['booking'],
+                label_types = ['binary'],
+                states = ['state_one AND state_two'],
+                db_config = db_config,
+                matrix_directory = temp_dir,
+                user_metadata = {},
+                engine = engine,
+                builder_class=builders.LowMemoryCSVBuilder
+            )       
+
+            # make the entity-date table
+            entity_date_table_name = planner.builder.make_entity_date_table(
+                as_of_times=dates,
+                label_type='binary',
+                label_name='booking',
+                state = 'state_one AND state_two',
+                matrix_type='train',
+                matrix_uuid='my_uuid',
+                label_window='1 month'
+            )
+
+            csv_filename = planner.builder.write_labels_data(
+                label_name=label_name,
+                label_type=label_type,
+                label_window='1 month',
+                matrix_uuid='my_uuid',
+                entity_date_table_name=entity_date_table_name,
+            )
+            df = pd.DataFrame.from_dict({
+                'entity_id': [2, 3, 4, 4],
+                'as_of_date': ['2016-02-01', '2016-02-01', '2016-01-01', '2016-02-01'],
+                'booking': [0, 0, 1, 0],
+            }).set_index(['entity_id', 'as_of_date'])
+
+            result = pd.read_csv(csv_filename).set_index(['entity_id', 'as_of_date'])
+            test = (result == df)
+            assert(test.all().all())
+
 
 class TestMergeFeatureCSVs(TestCase):
     def test_merge_feature_csvs_lowmem(self):
@@ -388,6 +502,7 @@ class TestMergeFeatureCSVs(TestCase):
                 beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
                 label_names = ['booking'],
                 label_types = ['binary'],
+                states = ['state_one AND state_two'],
                 db_config = db_config,
                 matrix_directory = temp_dir,
                 user_metadata = {},
@@ -456,6 +571,7 @@ class TestMergeFeatureCSVs(TestCase):
                 beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
                 label_names = ['booking'],
                 label_types = ['binary'],
+                states = ['state_one AND state_two'],
                 db_config = db_config,
                 matrix_directory = temp_dir,
                 user_metadata = {},
@@ -566,6 +682,7 @@ def test_generate_plans():
         beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
         label_names = ['booking'],
         label_types = ['binary'],
+        states = ['state_one AND state_two'],
         db_config = db_config,
         user_metadata = {},
         matrix_directory = '', # this test won't write anything
@@ -598,7 +715,12 @@ class TestBuildMatrix(object):
         with testing.postgresql.Postgresql() as postgresql:
             # create an engine and generate a table with fake feature data
             engine = create_engine(postgresql.url())
-            create_features_and_labels_schemas(engine, features_tables, labels)
+            create_schemas(
+                engine=engine,
+                features_tables=features_tables,
+                labels=labels,
+                states=states
+            )
 
             dates = [datetime.datetime(2016, 1, 1, 0, 0),
                      datetime.datetime(2016, 2, 1, 0, 0),
@@ -609,6 +731,7 @@ class TestBuildMatrix(object):
                     beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
                     label_names = ['booking'],
                     label_types = ['binary'],
+                    states = ['state_one AND state_two'],
                     db_config = db_config,
                     matrix_directory = temp_dir,
                     user_metadata = {},
@@ -620,6 +743,7 @@ class TestBuildMatrix(object):
                 }
                 matrix_metadata = {
                     'matrix_id': 'hi',
+                    'state': 'state_one AND state_two',
                     'label_name': 'booking',
                     'end_time': datetime.datetime(2016, 3, 1, 0, 0),
                     'beginning_of_time': datetime.datetime(2016, 1, 1, 0, 0),
@@ -643,13 +767,18 @@ class TestBuildMatrix(object):
                 )
                 with open(matrix_filename, 'r') as f:
                     reader = csv.reader(f)
-                    assert(len([row for row in reader]) == 12)
+                    assert(len([row for row in reader]) == 6)
 
     def test_test_matrix(self):
         with testing.postgresql.Postgresql() as postgresql:
             # create an engine and generate a table with fake feature data
             engine = create_engine(postgresql.url())
-            create_features_and_labels_schemas(engine, features_tables, labels)
+            create_schemas(
+                engine=engine,
+                features_tables=features_tables,
+                labels=labels,
+                states=states
+            )
 
             dates = [datetime.datetime(2016, 1, 1, 0, 0),
                      datetime.datetime(2016, 2, 1, 0, 0),
@@ -660,6 +789,7 @@ class TestBuildMatrix(object):
                     beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
                     label_names = ['booking'],
                     label_types = ['binary'],
+                    states = ['state_one AND state_two'],
                     db_config = db_config,
                     matrix_directory = temp_dir,
                     user_metadata = {},
@@ -677,6 +807,7 @@ class TestBuildMatrix(object):
                 }
                 matrix_metadata = {
                     'matrix_id': 'hi',
+                    'state': 'state_one AND state_two',
                     'label_name': 'booking',
                     'end_time': datetime.datetime(2016, 3, 1, 0, 0),
                     'beginning_of_time': datetime.datetime(2016, 1, 1, 0, 0),
@@ -701,13 +832,18 @@ class TestBuildMatrix(object):
 
                 with open(matrix_filename, 'r') as f:
                     reader = csv.reader(f)
-                    assert(len([row for row in reader]) == 13)
+                    assert(len([row for row in reader]) == 6)
 
     def test_replace(self):
         with testing.postgresql.Postgresql() as postgresql:
             # create an engine and generate a table with fake feature data
             engine = create_engine(postgresql.url())
-            create_features_and_labels_schemas(engine, features_tables, labels)
+            create_schemas(
+                engine=engine,
+                features_tables=features_tables,
+                labels=labels,
+                states=states
+            )
 
             dates = [datetime.datetime(2016, 1, 1, 0, 0),
                      datetime.datetime(2016, 2, 1, 0, 0),
@@ -718,6 +854,7 @@ class TestBuildMatrix(object):
                     beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
                     label_names = ['booking'],
                     label_types = ['binary'],
+                    states = ['state_one AND state_two'],
                     db_config = db_config,
                     matrix_directory = temp_dir,
                     user_metadata = {},
@@ -736,6 +873,7 @@ class TestBuildMatrix(object):
                 }
                 matrix_metadata = {
                     'matrix_id': 'hi',
+                    'state': 'state_one AND state_two',
                     'label_name': 'booking',
                     'end_time': datetime.datetime(2016, 3, 1, 0, 0),
                     'beginning_of_time': datetime.datetime(2016, 1, 1, 0, 0),
@@ -757,10 +895,11 @@ class TestBuildMatrix(object):
                     temp_dir,
                     '{}.csv'.format(uuid)
                 )
+                print(matrix_filename)
 
                 with open(matrix_filename, 'r') as f:
                     reader = csv.reader(f)
-                    assert(len([row for row in reader]) == 13)
+                    assert(len([row for row in reader]) == 6)
 
                 # rerun
                 planner.builder.make_entity_date_table = Mock()


### PR DESCRIPTION
We want to be able to consider entity state when generating matrices; for example, whether or not a building was permitted at the time. The general data flow to include entity states is as follows:

Label Generation and Feature Generation *do not* include any state filtering. This is because we would like to iterate through different state filters within a given experiment. This required removing the existing state filter code from the LabelGenerator

State filtering happens when we create the entity_date table for a given matrix. In fact, the sparse state table is pretty close to what an entity date table should be. Because of this, when we construct the queries to grab labels and features from the database, we don't need to concern ourselves with states as long as we join with this table. At a high level, nothing else really needed to change. A lower level list of changes is below:

- Remove Builder#build_labels_query, replace with _all_labeled_entity_dates_query for train matrices.
- Add state handling to _all_labeled_entity_dates_query() and _all_valid_entity_dates_query()
- Modify Builder#write_labels_data to call _outer_join_query for both train and test matrices, since the branching logic they need is handled when creating the entity-date table.
- Remove as_of_times logic from outer_join_query, since this is handled when created the matrix's entity-date table
- Rename query string-returning methods to pseudo-private methods without the term 'build'.
- Rename tmp_entity_date to matrix_entity_date for clarity, make it into temporary table that doesn't need to be manually cleaned up in build_matrix
- Remove state handling from BinaryLabelGenerator as it is handled on the matrix level.
- Add state handling to Planner
- Move test logic for build_labels_query up one level into a new test for write_labels_data
- PEP8 fixes