### PR TITLE
Make state table functionality optional [Resolves #15]

### DIFF
--- a/architect/planner.py
+++ b/architect/planner.py
@@ -3,7 +3,7 @@ import itertools
 
 from metta import metta_io as metta
 
-from . import builders, utils
+from . import builders, utils, state_table_generators
 
 
 class Planner(object):
@@ -24,7 +24,7 @@ class Planner(object):
         self.beginning_of_time = beginning_of_time  # earliest time included in features
         self.label_names = label_names
         self.label_types = label_types
-        self.states = states
+        self.states = states or [state_table_generators.DEFAULT_ACTIVE_STATE]
         self.db_config = db_config
         self.matrix_directory = matrix_directory
         self.user_metadata = user_metadata

--- a/architect/state_table_generators.py
+++ b/architect/state_table_generators.py
@@ -21,15 +21,65 @@ class StateFilter(object):
         )
 
 
+DEFAULT_ACTIVE_STATE = 'active'
+
 class StateTableGenerator(object):
-    """Take a dense state table and create a sparse state table"""
-    def __init__(self, db_engine, experiment_hash):
+    """Create a table containing the state of entities on different dates
+
+    Throughout the class we will refer to two types of state tables:
+        'dense' and 'sparse'.
+
+    dense: A table containing entities and *time ranges* for different states
+        
+        An example of this would be a building permits table, with 
+        time ranges that buildings are permitted.
+
+        The expected format would be entity id/state/start/end
+
+    sparse: A table containing entities, dates, and boolean values for
+        different states.
+
+        These types of tables rarely exist in source data, but are useful
+        internally in pipelines to express state logic in SQL
+
+        For instance: '(in_jail OR booked) AND in_mental_health_facility'
+
+        The output format is entity id/date/state1/state3/state3...
+
+    The main interface of StateTableGenerator objects is the
+    `generate_sparse_table` method, which produces the latter
+    'sparse'-style table.
+
+    Args:
+        db_engine (sqlalchemy.engine)
+        experiment_hash (string) unique identifier for the experiment
+        events_table (string, optional) name of SQL table containing
+            outcome events for entities
+        dense_state_table (string, optional) name of SQL table containing
+            entities and state time ranges
+    """
+    def __init__(
+        self,
+        db_engine,
+        experiment_hash,
+        events_table=None,
+        dense_state_table=None
+    ):
         self.db_engine = db_engine
         self.experiment_hash = experiment_hash
+        self.dense_state_table = dense_state_table
+        self.events_table = events_table
 
     @property
     def sparse_table_name(self):
         return 'tmp_sparse_states_{}'.format(self.experiment_hash)
+
+    @property
+    def sparse_table_query_func(self):
+        if self.dense_state_table:
+            return self._sparse_table_query_from_dense
+        else:
+            return self._sparse_table_query_from_events
 
     def _all_known_states(self, dense_state_table):
         all_states = [
@@ -41,11 +91,19 @@ class StateTableGenerator(object):
         logging.info('Distinct states found: %s', all_states)
         return all_states
 
-    def _sparse_table_query(self, dense_state_table, as_of_dates):
+    def _sparse_table_query_from_dense(self, as_of_dates):
+        """A query to convert a dense-style state table to a 'sparse'-style
+        table containing a specific set of dates.
+
+        Args:
+        as_of_dates (list of datetime.date): Dates to calculate entity states as of
+
+        Returns: (string) A query to produce a sparse states table
+        """
         state_columns = [
             'bool_or(state = \'{desired_state}\') as {desired_state}'
             .format(desired_state=state)
-            for state in self._all_known_states(dense_state_table)
+            for state in self._all_known_states(self.dense_state_table)
         ]
         query = '''
             create table {sparse_state_table} as (
@@ -60,23 +118,56 @@ class StateTableGenerator(object):
             )
         '''.format(
             sparse_state_table=self.sparse_table_name,
-            dense_state_table=dense_state_table,
+            dense_state_table=self.dense_state_table,
             as_of_dates=[date.isoformat() for date in as_of_dates],
             state_column_string=', '.join(state_columns)
         )
         return query
 
-    def generate_sparse_table(self, dense_state_table, as_of_dates):
-        """
-        input table:
-        entity_id, state, start_date, end_date
+    def _sparse_table_query_from_events(self, as_of_dates):
+        """A query to convert an events table to a 'sparse'-style
+        table containing a specific set of dates.
 
-        output table:
-        entity_id, as_of_date, state_one, state_two
+        This will include all entities for all given dates
+
+        Args:
+        as_of_dates (list of datetime.date): Dates to calculate entity states as of
+
+        Returns: (string) A query to produce a sparse states table
         """
-        self.db_engine.execute(
-            self._sparse_table_query(dense_state_table, as_of_dates)
+
+        query = '''
+            create table {sparse_state_table} as (
+            select e.entity_id, a.as_of_date::timestamp, true {active_state}
+                from {events_table} e
+                cross join (select unnest(ARRAY{as_of_dates}) as as_of_date) a
+                group by e.entity_id, a.as_of_date
+            )
+        '''.format(
+            sparse_state_table=self.sparse_table_name,
+            events_table=self.events_table,
+            as_of_dates=[date.isoformat() for date in as_of_dates],
+            active_state=DEFAULT_ACTIVE_STATE 
         )
+        return query
+
+    def generate_sparse_table(self, as_of_dates):
+        """Convert the object's input table (either dense states or events)
+        into a sparse states table for the given as_of_dates
+
+        Args:
+            as_of_dates (list of datetime.dates) Dates to include in the sparse
+                state table
+        """
+        self._generate_sparse_table(self.sparse_table_query_func(as_of_dates))
+
+    def _generate_sparse_table(self, generate_query):
+        """Generate and index a sparse table from a given query
+
+        Args:
+            generate_query (string) A full query to generate a sparse table
+        """
+        self.db_engine.execute(generate_query)
         logging.info('Sparse state table generated')
         self.db_engine.execute(
             'create index on {} (entity_id, as_of_date)'

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -176,7 +176,8 @@ def basic_integration_test(
 
             state_table_generator = StateTableGenerator(
                 db_engine=db_engine,
-                experiment_hash='abcd'
+                experiment_hash='abcd',
+                dense_state_table='states',
             )
 
             label_generator = BinaryLabelGenerator(
@@ -229,7 +230,6 @@ def basic_integration_test(
 
             # generate sparse state table
             state_table_generator.generate_sparse_table(
-                dense_state_table='states',
                 as_of_dates=all_as_of_times
             )
 

--- a/tests/test_label_generators.py
+++ b/tests/test_label_generators.py
@@ -2,6 +2,7 @@ from architect.label_generators import BinaryLabelGenerator
 import testing.postgresql
 from sqlalchemy import create_engine
 from datetime import date, timedelta
+from tests.utils import create_binary_outcome_events
 
 events_data = [
     # entity id, event_date, outcome
@@ -20,21 +21,10 @@ events_data = [
 ]
 
 
-def create_events(engine):
-    engine.execute(
-        'create table events (entity_id int, outcome_date date, outcome bool)'
-    )
-    for event in events_data:
-        engine.execute(
-            'insert into events values (%s, %s, %s::bool)',
-            event
-        )
-
-
 def test_training_label_generation():
     with testing.postgresql.Postgresql() as postgresql:
         engine = create_engine(postgresql.url())
-        create_events(engine)
+        create_binary_outcome_events(engine, 'events', events_data)
 
         labels_table_name = 'labels'
 
@@ -67,7 +57,7 @@ def test_training_label_generation():
 def test_generate_all_labels():
     with testing.postgresql.Postgresql() as postgresql:
         engine = create_engine(postgresql.url())
-        create_events(engine)
+        create_binary_outcome_events(engine, 'events', events_data)
 
         labels_table_name = 'labels'
 

--- a/tests/test_state_table_generators.py
+++ b/tests/test_state_table_generators.py
@@ -2,7 +2,7 @@ from architect.state_table_generators import StateTableGenerator
 import testing.postgresql
 from datetime import datetime
 from sqlalchemy.engine import create_engine
-from tests.utils import assert_index, create_dense_state_table
+from tests.utils import assert_index, create_dense_state_table, create_binary_outcome_events
 
 
 def test_sparse_state_table_generator():
@@ -17,7 +17,11 @@ def test_sparse_state_table_generator():
         engine = create_engine(postgresql.url())
         create_dense_state_table(engine, 'states', input_data)
 
-        table_generator = StateTableGenerator(engine, 'exp_hash')
+        table_generator = StateTableGenerator(
+            engine,
+            'exp_hash',
+            dense_state_table='states'
+        )
         as_of_dates = [
             datetime(2016, 1, 1),
             datetime(2016, 2, 1),
@@ -26,7 +30,7 @@ def test_sparse_state_table_generator():
             datetime(2016, 5, 1),
             datetime(2016, 6, 1),
         ]
-        table_generator.generate_sparse_table('states', as_of_dates)
+        table_generator.generate_sparse_table(as_of_dates)
         results = [row for row in engine.execute(
             'select entity_id, as_of_date, injail, permitted from {} order by entity_id, as_of_date'.format(
                 table_generator.sparse_table_name
@@ -43,6 +47,73 @@ def test_sparse_state_table_generator():
             (6, datetime(2016, 4, 1), False, True),
             (6, datetime(2016, 5, 1), False, True),
         ]
+        assert results == expected_output
+        assert_index(engine, table_generator.sparse_table_name, 'entity_id')
+        assert_index(engine, table_generator.sparse_table_name, 'as_of_date')
+
+
+def test_sparse_table_generator_from_events():
+    input_data = [
+        (1, datetime(2016, 1, 1), True),
+        (1, datetime(2016, 4, 1), False),
+        (1, datetime(2016, 3, 1), True),
+        (2, datetime(2016, 1, 1), False),
+        (2, datetime(2016, 1, 1), True),
+        (3, datetime(2016, 1, 1), True),
+        (5, datetime(2016, 1, 1), True),
+        (5, datetime(2016, 1, 1), True),
+    ]
+    with testing.postgresql.Postgresql() as postgresql:
+        engine = create_engine(postgresql.url())
+        create_binary_outcome_events(engine, 'events', input_data)
+        table_generator = StateTableGenerator(
+            engine,
+            'exp_hash',
+            events_table='events'
+        )
+        as_of_dates = [
+            datetime(2016, 1, 1),
+            datetime(2016, 2, 1),
+            datetime(2016, 3, 1),
+            datetime(2016, 4, 1),
+            datetime(2016, 5, 1),
+            datetime(2016, 6, 1),
+        ]
+        table_generator.generate_sparse_table(as_of_dates)
+        expected_output = [
+            (1, datetime(2016, 1, 1), True),
+            (1, datetime(2016, 2, 1), True),
+            (1, datetime(2016, 3, 1), True),
+            (1, datetime(2016, 4, 1), True),
+            (1, datetime(2016, 5, 1), True),
+            (1, datetime(2016, 6, 1), True),
+            (2, datetime(2016, 1, 1), True),
+            (2, datetime(2016, 2, 1), True),
+            (2, datetime(2016, 3, 1), True),
+            (2, datetime(2016, 4, 1), True),
+            (2, datetime(2016, 5, 1), True),
+            (2, datetime(2016, 6, 1), True),
+            (3, datetime(2016, 1, 1), True),
+            (3, datetime(2016, 2, 1), True),
+            (3, datetime(2016, 3, 1), True),
+            (3, datetime(2016, 4, 1), True),
+            (3, datetime(2016, 5, 1), True),
+            (3, datetime(2016, 6, 1), True),
+            (5, datetime(2016, 1, 1), True),
+            (5, datetime(2016, 2, 1), True),
+            (5, datetime(2016, 3, 1), True),
+            (5, datetime(2016, 4, 1), True),
+            (5, datetime(2016, 5, 1), True),
+            (5, datetime(2016, 6, 1), True),
+        ]
+        results = [row for row in engine.execute(
+            '''
+                select entity_id, as_of_date, active from {}
+                order by entity_id, as_of_date
+            '''.format(
+                table_generator.sparse_table_name
+            )
+        )]
         assert results == expected_output
         assert_index(engine, table_generator.sparse_table_name, 'entity_id')
         assert_index(engine, table_generator.sparse_table_name, 'as_of_date')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -246,3 +246,14 @@ def create_dense_state_table(db_engine, table_name, data):
             'insert into {} values (%s, %s, %s, %s)'.format(table_name),
             row
         )
+
+
+def create_binary_outcome_events(db_engine, table_name, events_data):
+    db_engine.execute(
+        'create table events (entity_id int, outcome_date date, outcome bool)'
+    )
+    for event in events_data:
+        db_engine.execute(
+            'insert into {} values (%s, %s, %s::bool)'.format(table_name),
+            event
+        )


### PR DESCRIPTION
- Allow StateTableGenerator to create an all-'active' state table from a passed-in events table
- Add events data creator to tests.utils, use in both state table and label generator test
- Modify Planner to include generic 'active' state if no state configuration is given