### PR TITLE
Component Validation [Resolves #8]

### DIFF
--- a/architect/builders.py
+++ b/architect/builders.py
@@ -13,6 +13,16 @@ class BuilderBase(object):
         self.engine = engine
         self.replace = replace
 
+    def validate(self):
+        for expected_db_config_val in [
+            'features_schema_name',
+            'sparse_state_table_name',
+            'labels_schema_name',
+            'labels_table_name'
+        ]:
+            if expected_db_config_val not in self.db_config:
+                raise ValueError('{} needed in db_config'.format(expected_db_config_val))
+
     def build_all_matrices(self, build_tasks):
         logging.info('Building %s matrices', len(build_tasks.keys()))
         for matrix_uuid, task_arguments in build_tasks.items():

--- a/architect/database_reflection.py
+++ b/architect/database_reflection.py
@@ -1,0 +1,116 @@
+"""Functions to retrieve basic information about tables in a Postgres database"""
+from sqlalchemy import MetaData, Table
+
+
+def split_table(table_name):
+    """Split a fully-qualified table name into schema and table
+
+    Args:
+        table_name (string) A table name, either with or without a schema prefix
+
+    Returns: (tuple) of schema and table name
+    """
+    table_parts = table_name.split('.')
+    if len(table_parts) == 2:
+        return tuple(table_parts)
+    elif len(table_parts) == 1:
+        return (None, table_parts[0])
+    else:
+        raise ValueError('Table name in unknown format')
+
+
+def table_object(table_name, db_engine):
+    """Produce a table object for the given table name
+
+    This does not load data about the table from the engine yet,
+    so it is safe to call for a table that doesn't exist.
+
+    Args:
+        table_name (string) A table name (with schema)
+        db_engine (sqlalchemy.engine)
+
+    Returns: (sqlalchemy.Table)
+    """
+    schema, table = split_table(table_name)
+    meta = MetaData(schema=schema, bind=db_engine)
+    return Table(table, meta)
+
+
+def reflected_table(table_name, db_engine):
+    """Produce a loaded table object for the given table name
+
+    Will attempt to load the metadata about the table from the database
+    So this will fail if the table doesn't exist.
+
+    Args:
+        table_name (string) A table name (with schema)
+        db_engine (sqlalchemy.engine)
+
+    Returns: (sqlalchemy.Table) A loaded table object
+    """
+    schema, table = split_table(table_name)
+    meta = MetaData(schema=schema, bind=db_engine)
+    return Table(table, meta, autoload=True, autoload_from=db_engine)
+
+
+def table_exists(table_name, db_engine):
+    """Checks whether the table exists
+
+    Args:
+        table_name (string) A table name (with schema)
+        db_engine (sqlalchemy.engine)
+
+    Returns: (boolean) Whether or not the table exists in the database
+    """
+    return table_object(table_name, db_engine).exists()
+
+
+def table_has_data(table_name, db_engine):
+    """Check whether the table contains any data
+
+    The table is expected to exist.
+
+    Args:
+        table_name (string) A table name (with schema)
+        db_engine (sqlalchemy.engine)
+
+    Returns: (boolean) Whether or not the table has any data
+    """
+    results = [
+        row for row in
+        db_engine.execute('select * from {} limit 1'.format(table_name))
+    ]
+
+    return len(results) > 0
+
+
+def table_has_column(table_name, column, db_engine):
+    """Check whether the table contains a column of the given name
+
+    The table is expected to exist.
+
+    Args:
+        table_name (string) A table name (with schema)
+        column (string) A column name
+        db_engine (sqlalchemy.engine)
+
+    Returns: (boolean) Whether or not the table contains the column
+    """
+    return column in reflected_table(table_name, db_engine).columns
+
+
+def column_type(table_name, column, db_engine):
+    """Find the database type of the given column in the given table
+
+    The table is expected to exist, and contain a column of the given name
+
+    Args:
+        table_name (string) A table name (with schema)
+        column (string) A column name
+        db_engine (sqlalchemy.engine)
+
+    Returns: (sqlalchemy.types) The DDL type of the column; For instance,
+        sqlalchemy.types.BOOLEAN instead of
+        sqlalchemy.types.Boolean
+    """
+    return type(reflected_table(table_name, db_engine).columns[column].type)

--- a/architect/feature_group_creator.py
+++ b/architect/feature_group_creator.py
@@ -36,9 +36,18 @@ class FeatureGroupCreator(object):
         """
         self.definition = definition
 
-        for subsetter in self.definition.keys():
-            if subsetter not in self.subsetters:
-                raise KeyError('Unknown subsetter %s received', subsetter)
+    def validate(self):
+        """Validate the object's configuration
+
+        """
+        if not isinstance(self.definition, dict):
+            raise ValueError('Feature Group Definition must be a dictionary')
+
+        for subsetter_name, value in self.definition.items():
+            if subsetter_name not in self.subsetters:
+                raise ValueError('Unknown subsetter %s received', subsetter_name)
+            if not hasattr(value, '__iter__') or isinstance(value, (str, bytes)):
+                raise ValueError('Each value in FeatureGroupCreator must be iterable and not a string')
 
     def subsets(self, feature_dictionary):
         """Generate subsets of a feature dict

--- a/architect/label_generators.py
+++ b/architect/label_generators.py
@@ -1,10 +1,20 @@
 import logging
+from architect.validations import table_should_have_data,\
+    column_should_be_intlike,\
+    column_should_be_booleanlike,\
+    column_should_be_timelike
 
 
 class BinaryLabelGenerator(object):
     def __init__(self, events_table, db_engine):
         self.events_table = events_table
         self.db_engine = db_engine
+
+    def validate(self):
+        table_should_have_data(self.events_table, self.db_engine)
+        column_should_be_intlike(self.events_table, 'entity_id', self.db_engine)
+        column_should_be_timelike(self.events_table, 'outcome_date', self.db_engine)
+        column_should_be_booleanlike(self.events_table, 'outcome', self.db_engine)
 
     def generate(
         self,

--- a/architect/planner.py
+++ b/architect/planner.py
@@ -7,7 +7,6 @@ from . import builders, utils, state_table_generators
 
 
 class Planner(object):
-
     def __init__(
         self,
         beginning_of_time,
@@ -36,6 +35,9 @@ class Planner(object):
             engine,
             replace
         )
+
+    def validate(self):
+        self.builder.validate()
 
     def _generate_build_task(
         self,

--- a/architect/utils.py
+++ b/architect/utils.py
@@ -5,6 +5,7 @@ import operator
 import warnings
 import re
 
+
 def convert_str_to_relativedelta(delta_string):
     """ Given a string in a postgres interval format (e.g., '1 month'),
     convert it to a dateutil.relativedelta.relativedelta.

--- a/architect/validations.py
+++ b/architect/validations.py
@@ -1,0 +1,149 @@
+"""Functions for validating input, mostly around database schema and state"""
+from architect.database_reflection import\
+    table_exists,\
+    table_has_column,\
+    column_type,\
+    table_has_data
+from sqlalchemy.types import\
+    BIGINT,\
+    BOOLEAN,\
+    DATE,\
+    DATETIME,\
+    INTEGER,\
+    SMALLINT,\
+    TEXT,\
+    TIMESTAMP,\
+    VARCHAR
+from sqlalchemy.dialects.postgresql.base import TIMESTAMP as POSTGRES_TIMESTAMP
+
+
+def table_should_exist(table_name, db_engine):
+    """Ensures that the table exists in the given database
+
+    Args:
+        table_name (string) A table name (with schema)
+        db_engine (sqlalchemy.engine)
+
+    Raises: ValueError if the table does not exist
+    """
+    if not table_exists(table_name, db_engine):
+        raise ValueError('{} table does not exist'.format(table_name))
+
+
+def table_should_have_column(table_name, column, db_engine):
+    """Ensures that the table has the given column
+
+    Args:
+        table_name (string) A table name (with schema)
+        column (string) The name of a column
+        db_engine (sqlalchemy.engine)
+
+    Raises: ValueError if the table does not contain the column
+    """
+    table_should_exist(table_name, db_engine)
+    if not table_has_column(table_name, column, db_engine):
+        raise ValueError('{} table does not have {} column'.format(table_name, column))
+
+
+def table_should_have_data(table_name, db_engine):
+    """Ensures that the table has at least one row
+
+    Args:
+        table_name (string) A table name (with schema)
+        db_engine (sqlalchemy.engine)
+
+    Raises: ValueError if the table does not have at least one row
+    """
+    table_should_exist(table_name, db_engine)
+    if not table_has_data(table_name, db_engine):
+        raise ValueError('{} table does not have any data'.format(table_name))
+
+
+def column_should_be_in_types(table_name, column, valid_types, db_engine):
+    """Ensures that the given column is one of the given types
+
+    Args:
+        table_name (string) A table name (with schema)
+        column (string) The name of a column
+        valid_types (list) A list of SQLAlchemy DDL types, like sqlalchemy.types.BOOLEAN
+        db_engine (sqlalchemy.engine)
+
+    Raises: ValueError if the column is not one of the given types
+    """
+    table_should_have_column(table_name, column, db_engine)
+    reflected_type = column_type(table_name, column, db_engine)
+    if reflected_type not in valid_types:
+        raise ValueError('{}.{} should be in types {} but was {}'.format(
+            table_name,
+            column,
+            valid_types,
+            reflected_type
+        ))
+
+
+def column_should_be_booleanlike(table_name, column, db_engine):
+    """Ensures that the given column can be casted to a boolean
+
+    Allows BOOLEAN, SMALLINT, and INTEGER, as these are commonly used.
+    It does not check that the data in a SMALLINT column all conforms to 0/1
+
+    Args:
+        table_name (string) A table name (with schema)
+        column (string) The name of a column
+        db_engine (sqlalchemy.engine)
+
+    Raises: ValueError if the column is not a recognized boolean-compatible type
+    """
+    table_should_have_column(table_name, column, db_engine)
+    column_should_be_in_types(table_name, column, [BOOLEAN, SMALLINT, INTEGER], db_engine)
+
+
+def column_should_be_timelike(table_name, column, db_engine):
+    """Ensures that the given column can be used for temporal data
+
+    Many date/time operations are fairly compatible with each other,
+    so this routine is fairly permissive. If you want to be more strict,
+    call column_should_be_in_types directly
+
+    Args:
+        table_name (string) A table name (with schema)
+        column (string) The name of a column
+        db_engine (sqlalchemy.engine)
+
+    Raises: ValueError if the column is not a recognized temporal type
+    """
+    table_should_have_column(table_name, column, db_engine)
+    column_should_be_in_types(
+        table_name,
+        column,
+        [DATE, DATETIME, TIMESTAMP, POSTGRES_TIMESTAMP],
+        db_engine
+    )
+
+
+def column_should_be_intlike(table_name, column, db_engine):
+    """Ensures that the given column can act as an integer
+
+    Args:
+        table_name (string) A table name (with schema)
+        column (string) The name of a column
+        db_engine (sqlalchemy.engine)
+
+    Raises: ValueError if the column is not a recognized integer type
+    """
+    table_should_have_column(table_name, column, db_engine)
+    column_should_be_in_types(table_name, column, [BIGINT, SMALLINT, INTEGER], db_engine)
+
+
+def column_should_be_stringlike(table_name, column, db_engine):
+    """Ensures that the given column can act as an string
+
+    Args:
+        table_name (string) A table name (with schema)
+        column (string) The name of a column
+        db_engine (sqlalchemy.engine)
+
+    Raises: ValueError if the column is not a recognized string type
+    """
+    table_should_have_column(table_name, column, db_engine)
+    column_should_be_in_types(table_name, column, [VARCHAR, TEXT], db_engine)

--- a/tests/test_database_reflection.py
+++ b/tests/test_database_reflection.py
@@ -1,0 +1,52 @@
+import architect.database_reflection as dbreflect
+from testing.postgresql import Postgresql
+from unittest import TestCase
+from sqlalchemy import create_engine
+from sqlalchemy import Table
+from sqlalchemy.types import VARCHAR
+
+
+class TestDatabaseReflection(TestCase):
+    def setUp(self):
+        self.postgresql = Postgresql()
+        self.engine = create_engine(self.postgresql.url())
+
+    def tearDown(self):
+        self.postgresql.stop()
+
+    def test_split_table(self):
+        assert dbreflect.split_table('staging.incidents') == ('staging', 'incidents')
+        assert dbreflect.split_table('incidents') == (None, 'incidents')
+        with self.assertRaises(ValueError):
+            dbreflect.split_table('blah.staging.incidents')
+
+    def test_table_object(self):
+        assert isinstance(
+            dbreflect.table_object('incidents', self.engine),
+            Table
+        )
+
+    def test_reflected_table(self):
+        self.engine.execute('create table incidents (col1 varchar)')
+        assert dbreflect.reflected_table('incidents', self.engine).exists()
+
+    def test_table_exists(self):
+        self.engine.execute('create table incidents (col1 varchar)')
+        assert dbreflect.table_exists('incidents', self.engine)
+        assert not dbreflect.table_exists('compliments', self.engine)
+
+    def test_table_has_data(self):
+        self.engine.execute('create table incidents (col1 varchar)')
+        self.engine.execute('create table compliments (col1 varchar)')
+        self.engine.execute('insert into compliments values (\'good job\')')
+        assert dbreflect.table_has_data('compliments', self.engine)
+        assert not dbreflect.table_has_data('incidents', self.engine)
+
+    def test_table_has_column(self):
+        self.engine.execute('create table incidents (col1 varchar)')
+        assert dbreflect.table_has_column('incidents', 'col1', self.engine)
+        assert not dbreflect.table_has_column('incidents', 'col2', self.engine)
+
+    def test_column_type(self):
+        self.engine.execute('create table incidents (col1 varchar)')
+        assert dbreflect.column_type('incidents', 'col1', self.engine) == VARCHAR

--- a/tests/test_feature_group_creator.py
+++ b/tests/test_feature_group_creator.py
@@ -1,4 +1,5 @@
 from architect.features import FeatureGroupCreator
+from unittest import TestCase
 
 
 def test_table_group():
@@ -51,3 +52,32 @@ def test_multiple_criteria():
         {'one': ['minor_a', 'minor_b', 'minor_c']},
         {'two': ['severe_a', 'severe_b', 'severe_c']},
     ]
+
+
+class TestValidations(TestCase):
+    def test_not_a_dict(self):
+        creator = FeatureGroupCreator(definition='prefix')
+        with self.assertRaises(ValueError):
+            creator.validate()
+
+    def test_badsubsetter(self):
+        creator = FeatureGroupCreator(definition={
+            'prefix': ['major', 'severe'],
+            'other': ['other'],
+        })
+        with self.assertRaises(ValueError):
+            creator.validate()
+
+    def test_stringvalue(self):
+        creator = FeatureGroupCreator(definition={
+            'prefix': 'major',
+        })
+        with self.assertRaises(ValueError):
+            creator.validate()
+
+    def test_goodconfig(self):
+        creator = FeatureGroupCreator(definition={
+            'prefix': ['major', 'severe'],
+            'tables': ['one', 'two'],
+        })
+        creator.validate()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -180,6 +180,7 @@ def basic_integration_test(
                 dense_state_table='states',
             )
 
+
             label_generator = BinaryLabelGenerator(
                 db_engine=db_engine,
                 events_table='events'
@@ -228,6 +229,34 @@ def basic_integration_test(
                     all_as_of_times.extend(test_matrix['as_of_times'])
             all_as_of_times = list(set(all_as_of_times))
 
+            feature_aggregation_config = [{
+                'prefix': 'cat',
+                'from_obj': 'cat_complaints',
+                'knowledge_date_column': 'as_of_date',
+                'aggregates': [{
+                    'quantity': 'cat_sightings',
+                    'metrics': ['count', 'avg'],
+                }],
+                'intervals': ['1y'],
+                'groups': ['entity_id']
+            }, {
+                'prefix': 'dog',
+                'from_obj': 'dog_complaints',
+                'knowledge_date_column': 'as_of_date',
+                'aggregates': [{
+                    'quantity': 'dog_sightings',
+                    'metrics': ['count', 'avg'],
+                }],
+                'intervals': ['1y'],
+                'groups': ['entity_id']
+            }]
+
+            state_table_generator.validate()
+            label_generator.validate()
+            feature_generator.validate(feature_aggregation_config)
+            feature_group_creator.validate()
+            planner.validate()
+
             # generate sparse state table
             state_table_generator.generate_sparse_table(
                 as_of_dates=all_as_of_times
@@ -244,27 +273,7 @@ def basic_integration_test(
             # we would use FeatureGenerator#create_all_tables but want to use
             # the tasks dict directly to create a feature dict
             feature_table_tasks = feature_generator.generate_all_table_tasks(
-                feature_aggregation_config=[{
-                    'prefix': 'cat',
-                    'from_obj': 'cat_complaints',
-                    'knowledge_date_column': 'as_of_date',
-                    'aggregates': [{
-                        'quantity': 'cat_sightings',
-                        'metrics': ['count', 'avg'],
-                    }],
-                    'intervals': ['1y'],
-                    'groups': ['entity_id']
-                }, {
-                    'prefix': 'dog',
-                    'from_obj': 'dog_complaints',
-                    'knowledge_date_column': 'as_of_date',
-                    'aggregates': [{
-                        'quantity': 'dog_sightings',
-                        'metrics': ['count', 'avg'],
-                    }],
-                    'intervals': ['1y'],
-                    'groups': ['entity_id']
-                }],
+                feature_aggregation_config=feature_aggregation_config,
                 feature_dates=all_as_of_times,
             )
 


### PR DESCRIPTION
Components should offer some validation on their inputs before they are forced to do computationally-intensive work. This pull request adds a `validate` method to the components here with meaningful configuration. Generally this has no parameters.

The FeatureGenerator validation is slightly different, as current the config isn't bound at object creation time. I think this is a flaw that we should fix, but didn't think it was suitable to mix that work in with this pull request, so the validation method takes the config as an parameter.

- Add database_reflection module to handle querying of database state
- Add validations module to define common validations
- Add validation methods to StateTableGenerator, LabelGenerator, FeatureGenerator, Planner, Builder, and FeatureGroupCreator
- Add validation calls to integration test to help defend against false positive validations