### PR TITLE
[WIP] Support collate imputation (Closes #21)

### DIFF
--- a/architect/feature_dictionary_creator.py
+++ b/architect/feature_dictionary_creator.py
@@ -10,7 +10,7 @@ class FeatureDictionaryCreator(object):
     def _tables_to_include(self, feature_table_names):
         return [
             feature_table for feature_table in feature_table_names
-            if 'aggregation' in feature_table
+            if 'aggregation_imputed' in feature_table
         ]
 
     def feature_dictionary(self, feature_table_names, index_column_lookup):

--- a/architect/feature_generators.py
+++ b/architect/feature_generators.py
@@ -51,12 +51,15 @@ class FeatureGenerator(object):
 
     def _validate_categoricals(self, categoricals):
         conn = self.db_engine.connect()
+        trans = conn.begin()
         for categorical in categoricals:
             if 'choice_query' in categorical:
                 logging.info('Validating choice query')
                 try:
                     conn.execute('explain {}'.format(categorical['choice_query']))
+                    trans.commit()
                 except Exception as e:
+                    trans.rollback()
                     raise ValueError(
                         'choice query does not run. \nchoice query: "{}"\nFull error: {}'
                         .format(categorical['choice_query'], e)
@@ -64,10 +67,13 @@ class FeatureGenerator(object):
 
     def _validate_from_obj(self, from_obj):
         conn = self.db_engine.connect()
+        trans = conn.begin()
         logging.info('Validating from_obj')
         try:
             conn.execute('explain select * from {}'.format(from_obj))
+            trans.commit()
         except Exception as e:
+            trans.rollback()
             raise ValueError(
                 'from_obj query does not run. \nfrom_obj: "{}"\nFull error: {}'
                 .format(from_obj, e)
@@ -83,6 +89,72 @@ class FeatureGenerator(object):
         if 'entity_id' not in groups:
             raise ValueError('One of the aggregation groups is required to be entity_id')
 
+    def _validate_imputation_rule(self, aggregate_type, impute_rule):
+        """Validate the imputation rule for a given aggregation type
+        """
+
+        # dictionary of imputation type : required parameters
+        valid_imputations = {
+            'all': {
+                'mean': [],
+                'constant': ['value'],
+                'zero': [],
+                'zero_noflag': [],
+                'error': []
+            },
+            'aggregates': {
+                'binary_mode': [],
+            },
+            'categoricals': {
+                'null_category': []
+            }
+        }
+        valid_imputations['array_categoricals'] = valid_imputations['categoricals']
+
+        # the valid imputation rules for the specific aggregation type being checked
+        valid_types = dict(valid_imputations['all'], **valid_imputations[aggregate_type])
+
+        # no imputation rule was specified
+        if 'type' not in impute_rule.keys():
+            raise ValueError('Imputation type must be specified')
+        
+        # a rule was specified, but not valid for this type of aggregate
+        if impute_rule['type'] not in valid_types.keys():
+            raise ValueError('Invalid imputation type %s for %s'\
+                 % (impute_rule['type'], aggregate_type))
+
+        # check that all required parameters exist in the keys of the imputation rule
+        required_params = valid_types[impute_rule['type']]
+        for param in required_params:
+            if param not in impute_rule.keys():
+                raise ValueError('Missing param %s for %s' % (param, impute_rule['type']))
+
+    def _validate_imputations(self, aggregation_config):
+        """Validate the imputation rules in an aggregation config, looping
+        through all three types of aggregates. Most of the work here is
+        done by _validate_imputation_rule() to check the requirements of
+        each imputation rule found
+        """
+        agg_types = ['aggregates', 'categoricals', 'array_categoricals']
+
+        for agg_type in agg_types:
+            # base_imp are the top-level rules, `such as aggregates_imputation`
+            base_imp = aggregation_config.get(agg_type+'_imputation', {})
+
+            # loop through the individual aggregates
+            for agg in aggregation_config.get(agg_type, []):
+                # combine any aggregate-level imputation rules with top-level ones
+                imp_dict = dict(base_imp, **agg.get('imputation', {}))
+
+                # imputation rules are metric-specific, so check each metric's rule
+                for metric in agg['metrics']:
+                    # metric rules may be defined by the metric name (e.g., 'max')
+                    # or with the 'all' catch-all, with named metrics taking
+                    # precedence. If we fall back to {}, the rule validator will
+                    # error out on no metric found.
+                    impute_rule = imp_dict.get(metric, imp_dict.get('all', {}))
+                    self._validate_imputation_rule(agg_type, impute_rule)
+
     def _validate_aggregation(self, aggregation_config):
         logging.info('Validating aggregation config %s', aggregation_config)
         self._validate_keys(aggregation_config)
@@ -91,6 +163,7 @@ class FeatureGenerator(object):
         self._validate_from_obj(aggregation_config['from_obj'])
         self._validate_time_intervals(aggregation_config['intervals'])
         self._validate_groups(aggregation_config['groups'])
+        self._validate_imputations(aggregation_config)
 
     def validate(self, feature_aggregation_config):
         """Validate a feature aggregation config applied to this object
@@ -109,16 +182,19 @@ class FeatureGenerator(object):
 
     def _compute_choices(self, choice_query):
         if choice_query not in self.categorical_cache:
+            conn = self.db_engine.connect()
+            trans = conn.begin()
             self.categorical_cache[choice_query] = [
                 row[0]
                 for row
-                in self.db_engine.execute(choice_query)
+                in conn.execute(choice_query)
             ]
             logging.info(
                 'Computed list of categoricals: %s for choice query: %s',
                 self.categorical_cache[choice_query],
                 choice_query
             )
+            trans.commit()
         return self.categorical_cache[choice_query]
 
     def _build_choices(self, categorical):
@@ -133,17 +209,25 @@ class FeatureGenerator(object):
         else:
             return self._compute_choices(categorical['choice_query'])
 
-    def _build_categoricals(self, categorical_config):
+    def _build_categoricals(self, categorical_config, impute_rules):
+        # TODO: only include null flag where necessary
         return [
             Categorical(
                 col=categorical['column'],
                 choices=self._build_choices(categorical),
-                function=categorical['metrics']
+                function=categorical['metrics'],
+                impute_rules=dict(
+                    impute_rules, 
+                    coltype='categorical', 
+                    **categorical.get('imputation', {})
+                ),
+                include_null=True
             )
             for categorical in categorical_config
         ]
 
-    def _build_array_categoricals(self, categorical_config):
+    def _build_array_categoricals(self, categorical_config, impute_rules):
+        # TODO: only include null flag where necessary
         return [
             Compare(
                 col=categorical['column'],
@@ -154,29 +238,49 @@ class FeatureGenerator(object):
                     self._build_choices(categorical)
                 },
                 function=categorical['metrics'],
+                impute_rules=dict(
+                    impute_rules, 
+                    coltype='array_categorical', 
+                    **categorical.get('imputation', {})
+                ),
                 op_in_name=False,
                 quote_choices=False,
+                include_null=True
             )
             for categorical in categorical_config
         ]
 
-    def _aggregation(self, aggregation_config, feature_dates):
+    def _aggregation(self, aggregation_config, feature_dates, state_table):
         logging.info(
             'Building collate.SpacetimeAggregation for config %s and as_of_dates %s',
             aggregation_config,
             feature_dates
         )
+
+        # read top-level imputation rules from the aggregation config; we'll allow
+        # these to be overridden by imputation rules at the individual feature
+        # level as those get parsed as well
+        agimp = aggregation_config.get('aggregates_imputation', {})
+        catimp = aggregation_config.get('categoricals_imputation', {})
+        arrcatimp = aggregation_config.get('array_categoricals_imputation', {})
+
         aggregates = [
-            Aggregate(aggregate['quantity'], aggregate['metrics'])
+                Aggregate(
+                    aggregate['quantity'], 
+                    aggregate['metrics'], 
+                    dict(agimp, coltype='aggregate', **aggregate.get('imputation', {}))
+                )
             for aggregate in aggregation_config.get('aggregates', [])
         ]
         logging.info('Found %s quantity aggregates', len(aggregates))
         categoricals = self._build_categoricals(
-            aggregation_config.get('categoricals', [])
+            aggregation_config.get('categoricals', []),
+            catimp
         )
         logging.info('Found %s categorical aggregates', len(categoricals))
         array_categoricals = self._build_array_categoricals(
-            aggregation_config.get('array_categoricals', [])
+            aggregation_config.get('array_categoricals', []),
+            arrcatimp
         )
         logging.info('Found %s array categorical aggregates', len(array_categoricals))
         return SpacetimeAggregation(
@@ -185,6 +289,8 @@ class FeatureGenerator(object):
             intervals=aggregation_config['intervals'],
             groups=aggregation_config['groups'],
             dates=feature_dates,
+            state_table=state_table,
+            state_group=self.entity_id_column,
             date_column=aggregation_config['knowledge_date_column'],
             output_date_column='as_of_date',
             input_min_date=self.beginning_of_time,
@@ -192,59 +298,110 @@ class FeatureGenerator(object):
             prefix=aggregation_config['prefix']
         )
 
-    def aggregations(self, feature_aggregation_config, feature_dates):
+    def aggregations(self, feature_aggregation_config, feature_dates, state_table):
         """Creates collate.SpacetimeAggregations from the given arguments
 
         Args:
             feature_aggregation_config (list) all values, except for feature
                 date, necessary to instantiate a collate.SpacetimeAggregation
             feature_dates (list) dates to generate features as of
+            state_table (string) schema.table_name for state table with all entity/date pairs
 
         Returns: (list) collate.SpacetimeAggregations
         """
         return [
-            self._aggregation(aggregation_config, feature_dates)
+            self._aggregation(aggregation_config, feature_dates, state_table)
             for aggregation_config in feature_aggregation_config
         ]
 
-    def generate_all_table_tasks(self, aggregations):
+    def generate_all_table_tasks(self, aggregations, task_type):
         """Generates SQL commands for creating, populating, and indexing
         feature group tables
 
         Args:
             aggregations (list) collate.SpacetimeAggregation objects
+            type (str) either 'aggregation' or 'imputation'
 
         Returns: (dict) keys are group table names, values are themselves dicts,
             each with keys for different stages of table creation (prepare, inserts, finalize)
             and with values being lists of SQL commands
         """
+
         logging.debug('---------------------')
-        logging.debug('---------FEATURE GENERATION------------')
+
+        # pick the method to use for generating tasks depending on whether we're
+        # building the aggregations or imputations
+        if task_type=='aggregation':
+            task_generator = self._generate_agg_table_tasks_for
+            logging.debug('---------FEATURE GENERATION------------')
+        elif task_type=='imputation':
+            task_generator = self._generate_imp_table_tasks_for
+            logging.debug('---------FEATURE IMPUTATION------------')
+        else:
+            raise ValueError('Table task type must be aggregation or imputation')
+
         logging.debug('---------------------')
+
         table_tasks = OrderedDict()
         for aggregation in aggregations:
-            table_tasks.update(self._generate_table_tasks_for(aggregation))
+            table_tasks.update(task_generator(aggregation))
         logging.info('Created %s tables', len(table_tasks.keys()))
         return table_tasks
 
-    def create_all_tables(self, feature_aggregation_config, feature_dates):
-        """Creates all feature tables.
+    def create_all_tables(self, feature_aggregation_config, feature_dates, state_table):
+        """Creates all feature tables, first building the aggregation tables
+        and then performing imputation on any null values (requires a two-
+        step process to determine which columns contain nulls after the
+        initial aggregation tables are built)
 
         Args:
             feature_aggregation_config (list) all values, except for feature
                 date, necessary to instantiate a collate.SpacetimeAggregation
             feature_dates (list) dates to generate features as of
+            state_table (string) schema.table_name for state table with all entity/date pairs
 
         Returns: (list) table names
         """
-        table_tasks = self.generate_all_table_tasks(
-            self.aggregations(
-                feature_aggregation_config,
-                feature_dates
-            )
-        )
 
-        return self.process_table_tasks(table_tasks)
+        aggs = self.aggregations(
+                    feature_aggregation_config,
+                    feature_dates,
+                    state_table
+                )
+
+        # first, generate and run table tasks for aggregations
+        table_tasks_aggregate = self.generate_all_table_tasks(
+            aggs,
+            task_type='aggregation'
+        )
+        aggregate_keys = self.process_table_tasks(table_tasks_aggregate)
+
+        # second, perform the imputations (this will query the tables
+        # constructed above to identify features containing nulls)
+        table_tasks_impute = self.generate_all_table_tasks(
+            aggs,
+            task_type='imputation'
+        )
+        impute_keys = self.process_table_tasks(table_tasks_impute)
+
+        # double-check that the imputation worked and no nulls remain
+        # in the data:
+        nullcols = []
+        for agg in aggs:
+            conn = self.db_engine.connect()
+            trans = conn.begin()
+            res = conn.execute(agg.find_nulls(imputed=True))
+            null_counts = list(zip(res.keys(), res.fetchone()))
+            nullcols += [col for col, val in null_counts if val > 0]
+            res.close()
+            trans.commit()
+        if len(nullcols) > 0:
+            raise ValueError(
+                "Imputation failed for {0} columns. Null values remain in: {1}"\
+                .format(len(nullcols), nullcols)
+                )
+
+        return impute_keys
 
     def process_table_tasks(self, table_tasks):
         for table_name, task in table_tasks.items():
@@ -256,12 +413,14 @@ class FeatureGenerator(object):
 
     def _explain_selects(self, aggregations):
         conn = self.db_engine.connect()
+        trans = conn.begin()
         for aggregation in aggregations:
             for selectlist in aggregation.get_selects().values():
                 for select in selectlist:
                     result = [row for row in conn.execute('explain ' + str(select))]
                     logging.debug(str(select))
                     logging.debug(result)
+        trans.commit()
 
     def _clean_table_name(self, table_name):
         # remove the schema and quotes from the name
@@ -269,14 +428,18 @@ class FeatureGenerator(object):
 
     def _table_exists(self, table_name):
         try:
-            self.db_engine.execute(
+            conn = self.db_engine.connect()
+            trans = conn.begin()
+            res = conn.execute(
                 'select * from {}.{} limit 1'.format(
                     self.features_schema_name,
                     table_name
                 )
-            )
+            ).fetchall()
+            trans.commit()
             return True
         except sqlalchemy.exc.ProgrammingError:
+            trans.rollback()
             return False
 
     def run_commands(self, command_list):
@@ -288,9 +451,9 @@ class FeatureGenerator(object):
         trans.commit()
 
 
-    def _aggregation_index_query(self, aggregation):
+    def _aggregation_index_query(self, aggregation, imputed=False):
         return 'CREATE INDEX ON {} ({}, {})'.format(
-            aggregation.get_table_name(),
+            aggregation.get_table_name(imputed=imputed),
             self.entity_id_column,
             aggregation.output_date_column
         )
@@ -298,13 +461,13 @@ class FeatureGenerator(object):
     def _aggregation_index_columns(self, aggregation):
         return sorted([group for group in aggregation.groups.keys()] + [aggregation.output_date_column])
 
-    def index_column_lookup(self, aggregations):
+    def index_column_lookup(self, aggregations, imputed=True):
         return dict((
-            self._clean_table_name(aggregation.get_table_name()),
+            self._clean_table_name(aggregation.get_table_name(imputed=imputed)),
             self._aggregation_index_columns(aggregation)
         ) for aggregation in aggregations)
 
-    def _generate_table_tasks_for(self, aggregation):
+    def _generate_agg_table_tasks_for(self, aggregation):
         """Generates SQL commands for preparing, populating, and finalizing
         each feature group table in the given aggregation
 
@@ -324,14 +487,24 @@ class FeatureGenerator(object):
         inserts = aggregation.get_inserts()
 
         if create_schema is not None:
-            self.db_engine.execute(create_schema)
+            conn = self.db_engine.connect()
+            trans = conn.begin()
+            conn.execute(create_schema)
+            trans.commit()
 
         table_tasks = OrderedDict()
         for group in aggregation.groups:
             group_table = self._clean_table_name(
                 aggregation.get_table_name(group=group)
             )
-            if self.replace or not self._table_exists(group_table):
+            imputed_table = self._clean_table_name(
+                aggregation.get_table_name(imputed=True)
+            )
+            if self.replace or (
+                not self._table_exists(group_table) 
+                and 
+                not self._table_exists(imputed_table)
+                ):
                 table_tasks[group_table] = {
                     'prepare': [drops[group], creates[group]],
                     'inserts': inserts[group],
@@ -345,10 +518,91 @@ class FeatureGenerator(object):
                 )
                 table_tasks[group_table] = {}
         logging.info('Created table tasks for aggregation')
-        table_tasks[self._clean_table_name(aggregation.get_table_name())] = {
-            'prepare': [aggregation.get_drop(), aggregation.get_create()],
-            'inserts': [],
-            'finalize': [self._aggregation_index_query(aggregation)],
+        if self.replace or (
+            not self._table_exists(
+                self._clean_table_name(aggregation.get_table_name())
+                )
+            and
+            not self._table_exists(
+                self._clean_table_name(aggregation.get_table_name(imputed=True))
+                )
+            ):
+            table_tasks[self._clean_table_name(aggregation.get_table_name())] = {
+                'prepare': [aggregation.get_drop(), aggregation.get_create()],
+                'inserts': [],
+                'finalize': [self._aggregation_index_query(aggregation)],
+            }
+        else:
+            table_tasks[self._clean_table_name(aggregation.get_table_name())] = {}
+
+        return table_tasks
+
+    def _generate_imp_table_tasks_for(self, aggregation, drop_preagg=True):
+        """Generates SQL commands for preparing, populating, and finalizing
+        imputations for each feature group table in the given aggregation
+
+        Requires the existance of the underlying feature and aggregation
+        tables defined in _generate_agg_table_tasks_for()
+
+        Args:
+            aggregation (collate.SpacetimeAggregation)
+            drop_preagg: boolean to specify dropping pre-imputation tables
+
+        Returns: (dict) of structure {
+            'prepare': list of commands to prepare table for population
+            'inserts': list of commands to populate table
+            'finalize': list of commands to finalize table after population
         }
+        """
+        drops = aggregation.get_drops()
+
+        table_tasks = OrderedDict()
+
+        imp_tbl_name = self._clean_table_name(
+            aggregation.get_table_name(imputed=True)
+        )
+        if (not self.replace) and self._table_exists(imp_tbl_name):
+            logging.info(
+                'Skipping imputation table creation for %s',
+                imp_tbl_name
+            )
+            table_tasks[imp_tbl_name] = {}
+            return table_tasks
+
+        # excute query to find columns with null values and create lists of columns
+        # that do and do not need imputation when creating the imputation table
+        conn = self.db_engine.connect()
+        trans = conn.begin()
+        res = conn.execute(aggregation.find_nulls())
+        null_counts = list(zip(res.keys(), res.fetchone()))
+        impute_cols = [col for col, val in null_counts if val > 0]
+        nonimpute_cols = [col for col, val in null_counts if val == 0]
+        res.close()
+        trans.commit()
+
+        # table tasks for imputed aggregation table, most of the work is done here
+        # by collate's get_impute_create()
+        table_tasks[imp_tbl_name] = {
+            'prepare': [
+                aggregation.get_drop(imputed=True), 
+                aggregation.get_impute_create(
+                    impute_cols=impute_cols, 
+                    nonimpute_cols=nonimpute_cols
+                    )
+                ],
+            'inserts': [],
+            'finalize': [self._aggregation_index_query(aggregation, imputed=True)]
+        }
+        logging.info('Created table tasks for imputation: %s' % imp_tbl_name)
+
+        # do some cleanup:
+        # drop the group-level and aggregation tables, just leaving the
+        # imputation table if drop_preagg=True
+        if drop_preagg:
+            table_tasks[imp_tbl_name]['finalize'] =\
+                table_tasks[imp_tbl_name]['finalize'] +\
+                list(drops.values()) +\
+                [aggregation.get_drop()]
+            logging.info('Added drop table cleanup tasks: %s' % imp_tbl_name)
 
         return table_tasks

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 results-schema==1.0.3
-collate==0.2.1
+collate==0.3.0
 metta-data
 timechop

--- a/tests/test_feature_dictionary_creator.py
+++ b/tests/test_feature_dictionary_creator.py
@@ -35,6 +35,18 @@ def test_feature_dictionary_creator():
             )
         ''')
         engine.execute('''
+            create table features.prefix1_aggregation_imputed (
+                entity_id int,
+                as_of_date date,
+                zipcode text,
+                feature_one float,
+                feature_two float,
+                feature_three float,
+                feature_three_imp int,
+                feature_four float
+            )
+        ''')
+        engine.execute('''
             create table features.random_other_table (
                 another_column float
             )
@@ -45,11 +57,16 @@ def test_feature_dictionary_creator():
             db_engine=engine
         )
         feature_dictionary = creator.feature_dictionary(
-            feature_table_names=['prefix1_entity_id', 'prefix1_zip_code', 'prefix1_aggregation'],
+            feature_table_names=[
+                'prefix1_entity_id', 'prefix1_zip_code', 
+                'prefix1_aggregation', 'prefix1_aggregation_imputed'
+                ],
             index_column_lookup={
-                'prefix1_aggregation': ['entity_id', 'zipcode', 'as_of_date']
+                'prefix1_aggregation_imputed': ['entity_id', 'zipcode', 'as_of_date']
             }
         )
         assert feature_dictionary == {
-            'prefix1_aggregation': ['feature_one', 'feature_two', 'feature_three', 'feature_four'],
+            'prefix1_aggregation_imputed': [
+                'feature_one', 'feature_two', 'feature_three', 'feature_three_imp', 'feature_four'
+                ],
         }

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -236,6 +236,9 @@ def basic_integration_test(
                 'aggregates': [{
                     'quantity': 'cat_sightings',
                     'metrics': ['count', 'avg'],
+                    'imputation': {
+                        'all': {'type': 'mean'}
+                    }
                 }],
                 'intervals': ['1y'],
                 'groups': ['entity_id']
@@ -243,6 +246,11 @@ def basic_integration_test(
                 'prefix': 'dog',
                 'from_obj': 'dog_complaints',
                 'knowledge_date_column': 'as_of_date',
+                'aggregates_imputation': {
+                    'count': {'type': 'constant', 'value': 7},
+                    'sum': {'type': 'mean'},
+                    'avg': {'type': 'zero'}
+                },
                 'aggregates': [{
                     'quantity': 'dog_sightings',
                     'metrics': ['count', 'avg'],
@@ -280,6 +288,9 @@ def basic_integration_test(
                     'aggregates': [{
                         'quantity': 'cat_sightings',
                         'metrics': ['count', 'avg'],
+                        'imputation': {
+                            'all': {'type': 'mean'}
+                        }
                     }],
                     'intervals': ['1y'],
                     'groups': ['entity_id']
@@ -287,6 +298,11 @@ def basic_integration_test(
                     'prefix': 'dog',
                     'from_obj': 'dog_complaints',
                     'knowledge_date_column': 'as_of_date',
+                    'aggregates_imputation': {
+                        'count': {'type': 'constant', 'value': 7},
+                        'sum': {'type': 'mean'},
+                        'avg': {'type': 'zero'}
+                    },
                     'aggregates': [{
                         'quantity': 'dog_sightings',
                         'metrics': ['count', 'avg'],
@@ -295,16 +311,22 @@ def basic_integration_test(
                     'groups': ['entity_id']
                 }],
                 feature_dates=all_as_of_times,
+                state_table=state_table_generator.sparse_table_name
             )
-            feature_table_tasks = feature_generator.generate_all_table_tasks(aggregations)
+            feature_table_agg_tasks = feature_generator.generate_all_table_tasks(aggregations, task_type='aggregation')
 
-            # create feature tables
-            feature_generator.process_table_tasks(feature_table_tasks)
+            # create feature aggregation tables
+            feature_generator.process_table_tasks(feature_table_agg_tasks)
+
+            feature_table_imp_tasks = feature_generator.generate_all_table_tasks(aggregations, task_type='imputation')
+
+            # create feature imputation tables
+            feature_generator.process_table_tasks(feature_table_imp_tasks)
 
             # build feature dictionaries from feature tables and
             # subsetting config
             master_feature_dict = feature_dictionary_creator.feature_dictionary(
-                feature_table_names=feature_table_tasks.keys(),
+                feature_table_names=feature_table_imp_tasks.keys(),
                 index_column_lookup=feature_generator.index_column_lookup(aggregations)
             )
 


### PR DESCRIPTION
Make architect work with the new collate imputation methods developed [here](https://github.com/dssg/collate/pull/101)

A couple of notes:
* Specifying imputation rules is now required in each aggregation config -- note that this **_will break_** current modeling configs and should be considered a new config version
* Additionally, truncation of long column names will cause the imputation code to break (see the collate PR for more), making more reasonable handling of these more important going forward
* The feature generator now needs to be passed the state table (with a comprehensive set of entities and as of dates) to generate the imputation table [@thcrock -- this is the WIP part of the PR]
* The zero-filling on export has been removed and the code will now raise an exception if NULL values are encountered on export
* Presently, all categoricals will generate a NULL category column (so may create a number of columns with only zeros) -- in the future, we may want to clean this up by only creating this category where NULL values exist