### PR TITLE
Moved requirement for sqlalchemy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+sqlalchemy
 results-schema==1.0.3
 collate==0.3.0
 metta-data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+psycopg2
 sqlalchemy
 results-schema==1.0.3
 collate==0.3.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,7 +7,6 @@ pytest==3.0.7
 codecov==2.0.9
 pytest-cov==2.5.1
 testing.postgresql==1.3.0
-sqlalchemy==1.1.9
 mock==2.0.0
 psycopg2==2.7.1
 timechop==0.1.5

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,5 +8,4 @@ codecov==2.0.9
 pytest-cov==2.5.1
 testing.postgresql==1.3.0
 mock==2.0.0
-psycopg2==2.7.1
 timechop==0.1.5


### PR DESCRIPTION
… from dev requirements file __requirements_dev.txt__ to base requirements file **requirements.txt**, to reflect that this library depends upon `sqlalchemy` explicitly in its production code.

(This worked because the dependent library, `triage`, built `sqlalchemy`; however, this *implicit* dependency resolution is dangerous.)