### PR TITLE
Pin timechop, update test [Resolves #53]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 results-schema==1.0.3
 collate==0.3.0
 metta-data
-timechop
+timechop==0.1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 results-schema==1.0.3
 collate==0.3.0
 metta-data
-timechop==0.1.5

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,3 +10,4 @@ testing.postgresql==1.3.0
 sqlalchemy==1.1.9
 mock==2.0.0
 psycopg2==2.7.1
+timechop==0.1.5


### PR DESCRIPTION
- Pin timechop to newest version (0.1.5)
- Update integration test to base expectations on runtime chop_time output, as opposed to hardcoding the number of expected matrices