### PR TITLE
49 | unclosed database connections

### DIFF
--- a/architect/feature_generators.py
+++ b/architect/feature_generators.py
@@ -538,15 +538,17 @@ class FeatureGenerator(object):
         return table_tasks
 
     def _generate_imp_table_tasks_for(self, aggregation, drop_preagg=True):
-        """Generates SQL commands for preparing, populating, and finalizing
-        imputations for each feature group table in the given aggregation
+        """Generate SQL statements for preparing, populating, and
+        finalizing imputations, for each feature group table in the
+        given aggregation.
 
         Requires the existance of the underlying feature and aggregation
-        tables defined in _generate_agg_table_tasks_for()
+        tables defined in `_generate_agg_table_tasks_for()`.
 
         Args:
             aggregation (collate.SpacetimeAggregation)
-            drop_preagg: boolean to specify dropping pre-imputation tables
+            drop_preagg: boolean to specify dropping pre-imputation
+                tables
 
         Returns: (dict) of structure {
                 'prepare': list of commands to prepare table for population
@@ -555,18 +557,14 @@ class FeatureGenerator(object):
             }
 
         """
-        drops = aggregation.get_drops()
-
         table_tasks = OrderedDict()
-
         imp_tbl_name = self._clean_table_name(
             aggregation.get_table_name(imputed=True)
         )
-        if (not self.replace) and self._table_exists(imp_tbl_name):
-            logging.info(
-                'Skipping imputation table creation for %s',
-                imp_tbl_name
-            )
+
+        if not self.replace and self._table_exists(imp_tbl_name):
+            logging.info('Skipping imputation table creation for %s',
+                         imp_tbl_name)
             table_tasks[imp_tbl_name] = {}
             return table_tasks
 
@@ -589,21 +587,20 @@ class FeatureGenerator(object):
                 aggregation.get_impute_create(
                     impute_cols=impute_cols,
                     nonimpute_cols=nonimpute_cols
-                    )
-                ],
+                )
+            ],
             'inserts': [],
             'finalize': [self._aggregation_index_query(aggregation, imputed=True)]
         }
-        logging.info('Created table tasks for imputation: %s' % imp_tbl_name)
+        logging.info('Created table tasks for imputation: %s', imp_tbl_name)
 
         # do some cleanup:
         # drop the group-level and aggregation tables, just leaving the
         # imputation table if drop_preagg=True
         if drop_preagg:
-            table_tasks[imp_tbl_name]['finalize'] =\
-                table_tasks[imp_tbl_name]['finalize'] +\
-                list(drops.values()) +\
-                [aggregation.get_drop()]
-            logging.info('Added drop table cleanup tasks: %s' % imp_tbl_name)
+            drops = aggregation.get_drops()
+            table_tasks[imp_tbl_name]['finalize'] += (list(drops.values()) +
+                                                      [aggregation.get_drop()])
+            logging.info('Added drop table cleanup tasks: %s', imp_tbl_name)
 
         return table_tasks

--- a/architect/feature_generators.py
+++ b/architect/feature_generators.py
@@ -345,20 +345,24 @@ class FeatureGenerator(object):
         return table_tasks
 
     def create_all_tables(self, feature_aggregation_config, feature_dates, state_table):
-        """Creates all feature tables, first building the aggregation tables
-        and then performing imputation on any null values (requires a two-
-        step process to determine which columns contain nulls after the
-        initial aggregation tables are built)
+        """Create all feature tables.
+
+        First builds the aggregation tables, and then performs
+        imputation on any null values, (requiring a two-step process to
+        determine which columns contain nulls after the initial
+        aggregation tables are built).
 
         Args:
-            feature_aggregation_config (list) all values, except for feature
-                date, necessary to instantiate a collate.SpacetimeAggregation
+            feature_aggregation_config (list) all values, except for
+                feature date, necessary to instantiate a
+                `collate.SpacetimeAggregation`
             feature_dates (list) dates to generate features as of
-            state_table (string) schema.table_name for state table with all entity/date pairs
+            state_table (string) schema.table_name for state table with
+                all entity/date pairs
 
         Returns: (list) table names
-        """
 
+        """
         aggs = self.aggregations(
             feature_aggregation_config,
             feature_dates,
@@ -383,11 +387,11 @@ class FeatureGenerator(object):
         # double-check that the imputation worked and no nulls remain
         # in the data:
         nullcols = []
-        for agg in aggs:
-            with self.db_engine.begin() as conn:
+        with self.db_engine.begin() as conn:
+            for agg in aggs:
                 results = conn.execute(agg.find_nulls(imputed=True))
                 null_counts = results.first().items()
-            nullcols += [col for (col, val) in null_counts if val > 0]
+                nullcols += [col for (col, val) in null_counts if val > 0]
 
         if len(nullcols) > 0:
             raise ValueError(


### PR DESCRIPTION
Ensure database connections and transactions are properly closed, regardless of querying errors, to prevent subsequent hanging.

> Database query errors -- unfortunately and incorrectly named `ProgrammerError` (for there's no such thing) -- must not prevent closure of the database connection.
>
> Under certain conditions, `FeatureGenerator` failed to close its database connection(s), such that, subsequently Triage could not clean up the state table

See the applicable [Sqlalchemy documentation](http://docs.sqlalchemy.org/en/latest/core/connections.html) for more information.

Changes likely make the most sense as per-commit diffs, as they include very minor clean-up, prior to applying the main fix, and subsequently applying the fix to all similar instances in the affected module.

Resolution of #49.