### PR TITLE
50 | fail fast if no states

### DIFF
--- a/architect/state_table_generators.py
+++ b/architect/state_table_generators.py
@@ -7,6 +7,7 @@ from architect.validations import table_should_have_data,\
 
 
 class StateFilter(object):
+
     def __init__(self, sparse_state_table, filter_logic):
         self.sparse_state_table = sparse_state_table
         self.filter_logic = filter_logic
@@ -63,6 +64,7 @@ class StateTableGenerator(object):
             outcome events for entities
         dense_state_table (string, optional) name of SQL table containing
             entities and state time ranges
+
     """
     def __init__(
         self,
@@ -131,10 +133,13 @@ class StateTableGenerator(object):
         Returns: (string) A query to produce a sparse states table
         """
         state_columns = [
-            'bool_or(state = \'{desired_state}\') as {desired_state}'
+            "bool_or(state = '{desired_state}') as {desired_state}"
             .format(desired_state=state)
             for state in self._all_known_states(self.dense_state_table)
         ]
+        if not state_columns:
+            raise ValueError("Unable to identify states from table",
+                             self.dense_state_table)
         query = '''
             create table {sparse_state_table} as (
             select d.entity_id, a.as_of_date::timestamp, {state_column_string}

--- a/architect/state_table_generators.py
+++ b/architect/state_table_generators.py
@@ -1,9 +1,12 @@
 import logging
-from architect.validations import table_should_have_data,\
-    column_should_be_intlike,\
-    column_should_be_booleanlike,\
-    column_should_be_timelike,\
-    column_should_be_stringlike
+
+from architect.validations import (
+    table_should_have_data,
+    column_should_be_intlike,
+    column_should_be_booleanlike,
+    column_should_be_timelike,
+    column_should_be_stringlike,
+)
 
 
 class StateFilter(object):
@@ -198,6 +201,7 @@ class StateTableGenerator(object):
         """
         logging.debug('Generating sparse table using as_of_dates: %s', as_of_dates)
         self._generate_sparse_table(self.sparse_table_query_func(as_of_dates))
+        table_should_have_data(self.sparse_table_name, self.db_engine)
 
     def _generate_sparse_table(self, generate_query):
         """Generate and index a sparse table from a given query


### PR DESCRIPTION
Eagerly raise (relatively meaningful) exceptions if either the input ("dense") state table _or_ the generated ("sparse") state table are empty.

Though the former is caught by validation, it's icky and confusing enough that I thought it worth making the code a little more careful. The latter, on the other hand, isn't covered by pre-run validation, and it's an easy mistake to make, (and which has been made in the wild). In either case, it's unnecessary and confusing to attempt to continue the run.

Resolves issue #50.