### PR TITLE
support new timechop names

### DIFF
--- a/architect/builders.py
+++ b/architect/builders.py
@@ -80,7 +80,7 @@ class BuilderBase(object):
         state,
         matrix_type,
         matrix_uuid,
-        label_window
+        label_timespan
     ):
         """ Make a table containing the entity_ids and as_of_dates required for
         the current matrix.
@@ -91,14 +91,14 @@ class BuilderBase(object):
         :param state: the entity state to be used in the matrix
         :param matrix_type: the type (train/test) of matrix
         :param matrix_uuid: a unique id for the matrix
-        :param label_window: the time window that labels in matrix will include
+        :param label_timespan: the time timespan that labels in matrix will include
         :type as_of_times: list
         :type label_name: str
         :type label_type: str
         :type state: str
         :type matrix_type: str
         :type matrix_uuid: str
-        :type label_window: str
+        :type label_timespan: str
 
         :return: table name
         :rtype: str
@@ -111,7 +111,7 @@ class BuilderBase(object):
                 state=state,
                 label_name=label_name,
                 label_type=label_type,
-                label_window=label_window
+                label_timespan=label_timespan
             )
         elif matrix_type == 'test':
             indices_query = self._all_valid_entity_dates_query(
@@ -142,7 +142,7 @@ class BuilderBase(object):
         state,
         label_name,
         label_type,
-        label_window
+        label_timespan
     ):
         query = """
             SELECT entity_id, as_of_date
@@ -152,7 +152,7 @@ class BuilderBase(object):
             AND as_of_date IN (SELECT (UNNEST (ARRAY{times}::timestamp[])))
             AND label_name = '{l_name}'
             AND label_type = '{l_type}'
-            AND label_window = '{window}'
+            AND label_timespan = '{timespan}'
             AND label is not null
             ORDER BY entity_id, as_of_date
         """.format(
@@ -162,7 +162,7 @@ class BuilderBase(object):
             labels_table_name=self.db_config['labels_table_name'],
             l_name=label_name,
             l_type=label_type,
-            window=label_window,
+            timespan=label_timespan,
             times=as_of_time_strings
         )
 
@@ -236,7 +236,7 @@ class CSVBuilder(BuilderBase):
             matrix_metadata['state'],
             matrix_type,
             matrix_uuid,
-            matrix_metadata['label_window']
+            matrix_metadata['label_timespan']
         )
         logging.info('Extracting feature group data from database into file for matrix %s', matrix_uuid)
         features_csv_names = self.write_features_data(
@@ -252,7 +252,7 @@ class CSVBuilder(BuilderBase):
                 label_type,
                 entity_date_table_name,
                 matrix_uuid,
-                matrix_metadata['label_window']
+                matrix_metadata['label_timespan']
             )
             features_csv_names.insert(0, labels_csv_name)
 
@@ -287,7 +287,7 @@ class CSVBuilder(BuilderBase):
         label_type,
         entity_date_table_name,
         matrix_uuid,
-        label_window
+        label_timespan
     ):
         """ Query the labels table and write the data to disk in csv format.
 
@@ -296,12 +296,12 @@ class CSVBuilder(BuilderBase):
         :param label_type: the type of label to be used
         :param entity_date_table_name: the name of the entity date table
         :param matrix_uuid: a unique id for the matrix
-        :param label_window: the time window that labels in matrix will include
+        :param label_timespan: the time timespan that labels in matrix will include
         :type label_name: str
         :type label_type: str
         :type entity_date_table_name: str
         :type matrix_uuid: str
-        :type label_window: str
+        :type label_timespan: str
 
         :return: name of csv containing labels
         :rtype: str
@@ -323,11 +323,11 @@ class CSVBuilder(BuilderBase):
             additional_conditions='''AND
                 r.label_name = '{name}' AND
                 r.label_type = '{type}' AND
-                r.label_window = '{window}'
+                r.label_timespan = '{timespan}'
             '''.format(
                 name=label_name,
                 type=label_type,
-                window=label_window
+                timespan=label_timespan
             )
         )
 

--- a/architect/feature_generators.py
+++ b/architect/feature_generators.py
@@ -12,7 +12,7 @@ class FeatureGenerator(object):
         db_engine,
         features_schema_name,
         replace=True,
-        beginning_of_time=None
+        feature_start_time=None
     ):
         """Generates aggregate features using collate
 
@@ -22,14 +22,14 @@ class FeatureGenerator(object):
                 tables should be written to
             replace (boolean, optional) Whether or not existing features
                 should be replaced
-            beginning_of_time (string/datetime, optional) point in time before which
+            feature_start_time (string/datetime, optional) point in time before which
                 should not be included in features
         """
         self.db_engine = db_engine
         self.features_schema_name = features_schema_name
         self.categorical_cache = {}
         self.replace = replace
-        self.beginning_of_time = beginning_of_time
+        self.feature_start_time = feature_start_time
         self.entity_id_column = 'entity_id'
 
     def _validate_keys(self, aggregation_config):
@@ -293,7 +293,7 @@ class FeatureGenerator(object):
             state_group=self.entity_id_column,
             date_column=aggregation_config['knowledge_date_column'],
             output_date_column='as_of_date',
-            input_min_date=self.beginning_of_time,
+            input_min_date=self.feature_start_time,
             schema=self.features_schema_name,
             prefix=aggregation_config['prefix']
         )

--- a/architect/planner.py
+++ b/architect/planner.py
@@ -83,14 +83,14 @@ class Planner(object):
         matrix_id = '_'.join([
             label_name,
             label_type,
-            str(matrix_definition['matrix_start_time']),
-            str(matrix_definition['matrix_end_time'])
+            str(matrix_definition['first_as_of_time']),
+            str(matrix_definition['matrix_info_end_time'])
         ])
         matrix_metadata = {
 
             # temporal information
             'beginning_of_time': self.beginning_of_time,
-            'end_time': matrix_definition['matrix_end_time'],
+            'end_time': matrix_definition['matrix_info_end_time'],
 
             # columns
             'indices': ['entity_id', 'as_of_date'],

--- a/architect/planner.py
+++ b/architect/planner.py
@@ -91,6 +91,10 @@ class Planner(object):
             # temporal information
             'beginning_of_time': self.beginning_of_time,
             'end_time': matrix_definition['matrix_info_end_time'],
+            'as_of_date_frequency': matrix_definition.get(
+                'training_as_of_date_frequency',
+                matrix_definition.get('test_as_of_date_frequency')
+            ),
 
             # columns
             'indices': ['entity_id', 'as_of_date'],
@@ -99,6 +103,10 @@ class Planner(object):
 
             # other information
             'label_type': label_type,
+            'label_timespan': matrix_definition.get(
+                'test_label_timespan', 
+                matrix_definition.get('training_label_timespan', '0 days')
+            ),
             'state': state,
             'matrix_id': matrix_id,
             'matrix_type': matrix_type
@@ -106,9 +114,6 @@ class Planner(object):
         }
         matrix_metadata.update(matrix_definition)
         matrix_metadata.update(self.user_metadata)
-
-        if 'prediction_window' not in matrix_definition.keys():
-            matrix_metadata['prediction_window'] = '0d'
 
         return(matrix_metadata)
 

--- a/architect/planner.py
+++ b/architect/planner.py
@@ -10,7 +10,7 @@ from . import builders, utils, state_table_generators
 class Planner(object):
     def __init__(
         self,
-        beginning_of_time,
+        feature_start_time,
         label_names,
         label_types,
         states,
@@ -21,7 +21,7 @@ class Planner(object):
         builder_class=builders.HighMemoryCSVBuilder,
         replace=True
     ):
-        self.beginning_of_time = beginning_of_time  # earliest time included in features
+        self.feature_start_time = feature_start_time  # earliest time included in features
         self.label_names = label_names
         self.label_types = label_types
         self.states = states or [state_table_generators.DEFAULT_ACTIVE_STATE]
@@ -89,7 +89,7 @@ class Planner(object):
         matrix_metadata = {
 
             # temporal information
-            'beginning_of_time': self.beginning_of_time,
+            'feature_start_time': self.feature_start_time,
             'end_time': matrix_definition['matrix_info_end_time'],
             'as_of_date_frequency': matrix_definition.get(
                 'training_as_of_date_frequency',

--- a/architect/utils.py
+++ b/architect/utils.py
@@ -11,7 +11,7 @@ def convert_str_to_relativedelta(delta_string):
     convert it to a dateutil.relativedelta.relativedelta.
 
     Assumptions:
-    - the prediction_window string is in the format 'value unit', where
+    - the label_timespan string is in the format 'value unit', where
       value is an int and unit is one of year(s), month(s), day(s),
       week(s), hour(s), minute(s), second(s), microsecond(s).
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 psycopg2
 sqlalchemy
-results-schema==1.0.3
+results-schema>=2.0
 collate==0.3.0
-metta-data
+metta-data>=1.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,4 +8,4 @@ codecov==2.0.9
 pytest-cov==2.5.1
 testing.postgresql==1.3.0
 mock==2.0.0
-timechop==0.1.5
+timechop==1.0.0

--- a/tests/test_feature_generators.py
+++ b/tests/test_feature_generators.py
@@ -273,7 +273,7 @@ def test_index_column_lookup():
         }
 
 
-def test_feature_generation_beginning_of_time():
+def test_feature_generation_feature_start_time():
     aggregate_config = [{
         'prefix': 'aprefix',
         'aggregates_imputation': {'all': {'type': 'constant', 'value': 7}},
@@ -314,7 +314,7 @@ def test_feature_generation_beginning_of_time():
         output_tables = FeatureGenerator(
             db_engine=engine,
             features_schema_name=features_schema_name,
-            beginning_of_time='2013-01-01',
+            feature_start_time='2013-01-01',
         ).create_all_tables(
             feature_dates=['2015-01-01'],
             feature_aggregation_config=aggregate_config,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -204,7 +204,7 @@ def basic_integration_test(
 
             planner = Planner(
                 engine=db_engine,
-                beginning_of_time=datetime(2010, 1, 1),
+                feature_start_time=datetime(2010, 1, 1),
                 label_names=['outcome'],
                 label_types=['binary'],
                 db_config={

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -162,15 +162,16 @@ def basic_integration_test(
 
         with TemporaryDirectory() as temp_dir:
             chopper = Timechop(
-                beginning_of_time=datetime(2010, 1, 1),
-                modeling_start_time=datetime(2011, 1, 1),
-                modeling_end_time=datetime(2014, 1, 1),
-                update_window='1y',
-                train_label_windows=['6months'],
-                test_label_windows=['6months'],
-                train_example_frequency='1day',
-                test_example_frequency='3months',
-                train_durations=['1months'],
+                feature_start_time=datetime(2010, 1, 1),
+                feature_end_time=datetime(2014, 1, 1),
+                label_start_time=datetime(2011, 1, 1),
+                label_end_time=datetime(2014, 1, 1),
+                model_update_frequency='1year',
+                training_label_timespans=['6months'],
+                test_label_timespans=['6months'],
+                training_as_of_date_frequencies='1day',
+                test_as_of_date_frequencies='3months',
+                max_training_histories=['1months'],
                 test_durations=['1months'],
             )
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -276,7 +276,7 @@ def basic_integration_test(
             label_generator.generate_all_labels(
                 labels_table='labels',
                 as_of_dates=all_as_of_times,
-                label_windows=['6months']
+                label_timespans=['6months']
             )
 
             # create feature table tasks

--- a/tests/test_label_generators.py
+++ b/tests/test_label_generators.py
@@ -35,7 +35,7 @@ def test_training_label_generation():
         label_generator._create_labels_table(labels_table_name)
         label_generator.generate(
             start_date='2014-09-30',
-            label_window='6month',
+            label_timespan='6month',
             labels_table=labels_table_name
         )
 
@@ -45,7 +45,7 @@ def test_training_label_generation():
         records = [row for row in result]
 
         expected = [
-            # entity_id, as_of_date, label_window, name, type, label
+            # entity_id, as_of_date, label_timespan, name, type, label
             (1, date(2014, 9, 30), timedelta(180), 'outcome', 'binary', False),
             (3, date(2014, 9, 30), timedelta(180), 'outcome', 'binary', True),
             (4, date(2014, 9, 30), timedelta(180), 'outcome', 'binary', False),
@@ -68,18 +68,18 @@ def test_generate_all_labels():
         label_generator.generate_all_labels(
             labels_table=labels_table_name,
             as_of_dates=['2014-09-30', '2015-03-30'],
-            label_windows=['6month', '3month'],
+            label_timespans=['6month', '3month'],
         )
 
         result = engine.execute('''
             select * from {}
-            order by entity_id, as_of_date, label_window desc
+            order by entity_id, as_of_date, label_timespan desc
         '''.format(labels_table_name)
         )
         records = [row for row in result]
 
         expected = [
-            # entity_id, as_of_date, label_window, name, type, label
+            # entity_id, as_of_date, label_timespan, name, type, label
             (1, date(2014, 9, 30), timedelta(180), 'outcome', 'binary', False),
             (1, date(2014, 9, 30), timedelta(90), 'outcome', 'binary', False),
             (2, date(2015, 3, 30), timedelta(180), 'outcome', 'binary', False),

--- a/tests/test_planner_builders.py
+++ b/tests/test_planner_builders.py
@@ -243,7 +243,7 @@ def test_write_to_csv():
 
         with TemporaryDirectory() as temp_dir:
             planner = Planner(
-                beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
+                feature_start_time = datetime.datetime(2010, 1, 1, 0, 0),
                 label_names = ['booking'],
                 label_types = ['binary'],
                 states = ['state_one AND state_two'],
@@ -299,7 +299,7 @@ def test_make_entity_date_table():
 
         with TemporaryDirectory() as temp_dir:
             planner = Planner(
-                beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
+                feature_start_time = datetime.datetime(2010, 1, 1, 0, 0),
                 label_names = ['booking'],
                 label_types = ['binary'],
                 states = ['state_one AND state_two'],
@@ -379,7 +379,7 @@ def test_write_features_data():
 
         with TemporaryDirectory() as temp_dir:
             planner = Planner(
-                beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
+                feature_start_time = datetime.datetime(2010, 1, 1, 0, 0),
                 label_names = ['booking'],
                 label_types = ['binary'],
                 states = ['state_one AND state_two'],
@@ -458,7 +458,7 @@ def test_write_labels_data():
         )
         with TemporaryDirectory() as temp_dir:
             planner = Planner(
-                beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
+                feature_start_time = datetime.datetime(2010, 1, 1, 0, 0),
                 label_names = ['booking'],
                 label_types = ['binary'],
                 states = ['state_one AND state_two'],
@@ -504,7 +504,7 @@ class TestMergeFeatureCSVs(TestCase):
         should result in an error"""
         with TemporaryDirectory() as temp_dir:
             planner = Planner(
-                beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
+                feature_start_time = datetime.datetime(2010, 1, 1, 0, 0),
                 label_names = ['booking'],
                 label_types = ['binary'],
                 states = ['state_one AND state_two'],
@@ -552,7 +552,7 @@ class TestMergeFeatureCSVs(TestCase):
 def test_generate_plans():
     matrix_set_definitions = [
         {
-            'beginning_of_time': datetime.datetime(1990, 1, 1, 0, 0),
+            'feature_start_time': datetime.datetime(1990, 1, 1, 0, 0),
             'modeling_start_time': datetime.datetime(2010, 1, 1, 0, 0),
             'modeling_end_time': datetime.datetime(2010, 1, 16, 0, 0),
             'train_matrix': {
@@ -579,7 +579,7 @@ def test_generate_plans():
             }]
         },
         {
-            'beginning_of_time': datetime.datetime(1990, 1, 1, 0, 0),
+            'feature_start_time': datetime.datetime(1990, 1, 1, 0, 0),
             'modeling_start_time': datetime.datetime(2010, 1, 1, 0, 0),
             'modeling_end_time': datetime.datetime(2010, 1, 16, 0, 0),
             'train_matrix': {
@@ -610,7 +610,7 @@ def test_generate_plans():
     feature_dict_two = {'features2': ['f3', 'f4'], 'features3': ['f5', 'f6']}
     feature_dicts = [feature_dict_one, feature_dict_two]
     planner = Planner(
-        beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
+        feature_start_time = datetime.datetime(2010, 1, 1, 0, 0),
         label_names = ['booking'],
         label_types = ['binary'],
         states = ['state_one AND state_two'],
@@ -659,7 +659,7 @@ class TestBuildMatrix(TestCase):
 
             with TemporaryDirectory() as temp_dir:
                 planner = Planner(
-                    beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
+                    feature_start_time = datetime.datetime(2010, 1, 1, 0, 0),
                     label_names = ['booking'],
                     label_types = ['binary'],
                     states = ['state_one AND state_two'],
@@ -677,7 +677,7 @@ class TestBuildMatrix(TestCase):
                     'state': 'state_one AND state_two',
                     'label_name': 'booking',
                     'end_time': datetime.datetime(2016, 3, 1, 0, 0),
-                    'beginning_of_time': datetime.datetime(2016, 1, 1, 0, 0),
+                    'feature_start_time': datetime.datetime(2016, 1, 1, 0, 0),
                     'label_timespan': '1 month'
                 }
                 uuid = metta.generate_uuid(matrix_metadata)
@@ -717,7 +717,7 @@ class TestBuildMatrix(TestCase):
 
             with TemporaryDirectory() as temp_dir:
                 planner = Planner(
-                    beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
+                    feature_start_time = datetime.datetime(2010, 1, 1, 0, 0),
                     label_names = ['booking'],
                     label_types = ['binary'],
                     states = ['state_one AND state_two'],
@@ -741,7 +741,7 @@ class TestBuildMatrix(TestCase):
                     'state': 'state_one AND state_two',
                     'label_name': 'booking',
                     'end_time': datetime.datetime(2016, 3, 1, 0, 0),
-                    'beginning_of_time': datetime.datetime(2016, 1, 1, 0, 0),
+                    'feature_start_time': datetime.datetime(2016, 1, 1, 0, 0),
                     'label_timespan': '1 month'
                 }
                 uuid = metta.generate_uuid(matrix_metadata)
@@ -790,7 +790,7 @@ class TestBuildMatrix(TestCase):
 
             with TemporaryDirectory() as temp_dir:
                 planner = Planner(
-                    beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
+                    feature_start_time = datetime.datetime(2010, 1, 1, 0, 0),
                     label_names = ['booking'],
                     label_types = ['binary'],
                     states = ['state_one AND state_two'],
@@ -814,7 +814,7 @@ class TestBuildMatrix(TestCase):
                     'state': 'state_one AND state_two',
                     'label_name': 'booking',
                     'end_time': datetime.datetime(2016, 3, 1, 0, 0),
-                    'beginning_of_time': datetime.datetime(2016, 1, 1, 0, 0),
+                    'feature_start_time': datetime.datetime(2016, 1, 1, 0, 0),
                     'label_timespan': '1 month'
                 }
                 uuid = metta.generate_uuid(matrix_metadata)
@@ -847,7 +847,7 @@ class TestBuildMatrix(TestCase):
 
             with TemporaryDirectory() as temp_dir:
                 planner = Planner(
-                    beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
+                    feature_start_time = datetime.datetime(2010, 1, 1, 0, 0),
                     label_names = ['booking'],
                     label_types = ['binary'],
                     states = ['state_one AND state_two'],
@@ -872,7 +872,7 @@ class TestBuildMatrix(TestCase):
                     'state': 'state_one AND state_two',
                     'label_name': 'booking',
                     'end_time': datetime.datetime(2016, 3, 1, 0, 0),
-                    'beginning_of_time': datetime.datetime(2016, 1, 1, 0, 0),
+                    'feature_start_time': datetime.datetime(2016, 1, 1, 0, 0),
                     'label_timespan': '1 month'
                 }
                 uuid = metta.generate_uuid(matrix_metadata)

--- a/tests/test_planner_builders.py
+++ b/tests/test_planner_builders.py
@@ -556,8 +556,8 @@ def test_generate_plans():
             'modeling_start_time': datetime.datetime(2010, 1, 1, 0, 0),
             'modeling_end_time': datetime.datetime(2010, 1, 16, 0, 0),
             'train_matrix': {
-                'matrix_start_time': datetime.datetime(2010, 1, 1, 0, 0),
-                'matrix_end_time': datetime.datetime(2010, 1, 6, 0, 0),
+                'first_as_of_time': datetime.datetime(2010, 1, 1, 0, 0),
+                'matrix_info_end_time': datetime.datetime(2010, 1, 6, 0, 0),
                 'as_of_times': [
                     datetime.datetime(2010, 1, 1, 0, 0),
                     datetime.datetime(2010, 1, 2, 0, 0),
@@ -567,8 +567,8 @@ def test_generate_plans():
                 ]
             },
             'test_matrices': [{
-                'matrix_start_time': datetime.datetime(2010, 1, 6, 0, 0),
-                'matrix_end_time': datetime.datetime(2010, 1, 11, 0, 0),
+                'first_as_of_time': datetime.datetime(2010, 1, 6, 0, 0),
+                'matrix_info_end_time': datetime.datetime(2010, 1, 11, 0, 0),
                 'as_of_times': [
                     datetime.datetime(2010, 1, 6, 0, 0),
                     datetime.datetime(2010, 1, 7, 0, 0),
@@ -583,8 +583,8 @@ def test_generate_plans():
             'modeling_start_time': datetime.datetime(2010, 1, 1, 0, 0),
             'modeling_end_time': datetime.datetime(2010, 1, 16, 0, 0),
             'train_matrix': {
-                'matrix_start_time': datetime.datetime(2010, 1, 6, 0, 0),
-                'matrix_end_time': datetime.datetime(2010, 1, 11, 0, 0),
+                'first_as_of_time': datetime.datetime(2010, 1, 6, 0, 0),
+                'matrix_info_end_time': datetime.datetime(2010, 1, 11, 0, 0),
                 'as_of_times': [
                     datetime.datetime(2010, 1, 6, 0, 0),
                     datetime.datetime(2010, 1, 7, 0, 0),
@@ -594,8 +594,8 @@ def test_generate_plans():
                 ]
             },
             'test_matrices': [{
-                'matrix_start_time': datetime.datetime(2010, 1, 11, 0, 0),
-                'matrix_end_time': datetime.datetime(2010, 1, 16, 0, 0),
+                'first_as_of_time': datetime.datetime(2010, 1, 11, 0, 0),
+                'matrix_info_end_time': datetime.datetime(2010, 1, 16, 0, 0),
                 'as_of_times': [
                     datetime.datetime(2010, 1, 11, 0, 0),
                     datetime.datetime(2010, 1, 12, 0, 0),
@@ -728,8 +728,8 @@ class TestBuildMatrix(TestCase):
                 )
 
                 matrix_dates = {
-                    'matrix_start_time': datetime.datetime(2016, 1, 1, 0, 0),
-                    'matrix_end_time': datetime.datetime(2016, 3, 1, 0, 0),
+                    'first_as_of_time': datetime.datetime(2016, 1, 1, 0, 0),
+                    'matrix_info_end_time': datetime.datetime(2016, 3, 1, 0, 0),
                     'as_of_times': dates
                 }
                 feature_dictionary = {
@@ -801,8 +801,8 @@ class TestBuildMatrix(TestCase):
                 )
 
                 matrix_dates = {
-                    'matrix_start_time': datetime.datetime(2016, 1, 1, 0, 0),
-                    'matrix_end_time': datetime.datetime(2016, 3, 1, 0, 0),
+                    'first_as_of_time': datetime.datetime(2016, 1, 1, 0, 0),
+                    'matrix_info_end_time': datetime.datetime(2016, 3, 1, 0, 0),
                     'as_of_times': dates
                 }
                 feature_dictionary = {
@@ -859,8 +859,8 @@ class TestBuildMatrix(TestCase):
                 )
 
                 matrix_dates = {
-                    'matrix_start_time': datetime.datetime(2016, 1, 1, 0, 0),
-                    'matrix_end_time': datetime.datetime(2016, 3, 1, 0, 0),
+                    'first_as_of_time': datetime.datetime(2016, 1, 1, 0, 0),
+                    'matrix_info_end_time': datetime.datetime(2016, 3, 1, 0, 0),
                     'as_of_times': dates
                 }
                 feature_dictionary = {

--- a/tests/test_planner_builders.py
+++ b/tests/test_planner_builders.py
@@ -284,7 +284,7 @@ def test_make_entity_date_table():
         state_two=True,
         label_name='booking',
         label_type='binary',
-        label_window='1 month'
+        label_timespan='1 month'
     )
 
     with testing.postgresql.Postgresql() as postgresql:
@@ -319,7 +319,7 @@ def test_make_entity_date_table():
                 state='state_one AND state_two',
                 matrix_uuid='my_uuid',
                 matrix_type='train',
-                label_window='1 month'
+                label_timespan='1 month'
             )
 
             # read in the table
@@ -346,7 +346,7 @@ def test_write_features_data():
         state_two=True,
         label_name='booking',
         label_type='binary',
-        label_window='1 month'
+        label_timespan='1 month'
     )
 
     features = [['f1', 'f2'], ['f3', 'f4']]
@@ -397,7 +397,7 @@ def test_write_features_data():
                 state = 'state_one AND state_two',
                 matrix_type='train',
                 matrix_uuid='my_uuid',
-                label_window='1 month'
+                label_timespan='1 month'
             )
 
             feature_dictionary = dict(
@@ -437,7 +437,7 @@ def test_write_labels_data():
         columns = [
             'entity_id',
             'as_of_date',
-            'label_window',
+            'label_timespan',
             'label_name',
             'label_type',
             'label'
@@ -476,13 +476,13 @@ def test_write_labels_data():
                 state = 'state_one AND state_two',
                 matrix_type='train',
                 matrix_uuid='my_uuid',
-                label_window='1 month'
+                label_timespan='1 month'
             )
 
             csv_filename = planner.builder.write_labels_data(
                 label_name=label_name,
                 label_type=label_type,
-                label_window='1 month',
+                label_timespan='1 month',
                 matrix_uuid='my_uuid',
                 entity_date_table_name=entity_date_table_name,
             )
@@ -678,7 +678,7 @@ class TestBuildMatrix(TestCase):
                     'label_name': 'booking',
                     'end_time': datetime.datetime(2016, 3, 1, 0, 0),
                     'beginning_of_time': datetime.datetime(2016, 1, 1, 0, 0),
-                    'label_window': '1 month'
+                    'label_timespan': '1 month'
                 }
                 uuid = metta.generate_uuid(matrix_metadata)
                 planner.build_matrix(
@@ -742,7 +742,7 @@ class TestBuildMatrix(TestCase):
                     'label_name': 'booking',
                     'end_time': datetime.datetime(2016, 3, 1, 0, 0),
                     'beginning_of_time': datetime.datetime(2016, 1, 1, 0, 0),
-                    'label_window': '1 month'
+                    'label_timespan': '1 month'
                 }
                 uuid = metta.generate_uuid(matrix_metadata)
                 planner.build_matrix(
@@ -815,7 +815,7 @@ class TestBuildMatrix(TestCase):
                     'label_name': 'booking',
                     'end_time': datetime.datetime(2016, 3, 1, 0, 0),
                     'beginning_of_time': datetime.datetime(2016, 1, 1, 0, 0),
-                    'label_window': '1 month'
+                    'label_timespan': '1 month'
                 }
                 uuid = metta.generate_uuid(matrix_metadata)
                 with self.assertRaises(ValueError):
@@ -873,7 +873,7 @@ class TestBuildMatrix(TestCase):
                     'label_name': 'booking',
                     'end_time': datetime.datetime(2016, 3, 1, 0, 0),
                     'beginning_of_time': datetime.datetime(2016, 1, 1, 0, 0),
-                    'label_window': '1 month'
+                    'label_timespan': '1 month'
                 }
                 uuid = metta.generate_uuid(matrix_metadata)
                 planner.build_matrix(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -35,7 +35,7 @@ def create_schemas(engine, features_tables, labels, states):
             create table labels.labels (
                 entity_id int,
                 as_of_date date,
-                label_window interval,
+                label_timespan interval,
                 label_name char(30),
                 label_type char(30),
                 label int
@@ -93,7 +93,7 @@ def create_entity_date_df(
     state_two,
     label_name,
     label_type,
-    label_window
+    label_timespan
 ):
     """ This function makes a pandas DataFrame that mimics the entity-date table
     for testing against.
@@ -102,7 +102,7 @@ def create_entity_date_df(
     labels_table = pd.DataFrame(labels, columns=[
         'entity_id',
         'as_of_date',
-        'label_window',
+        'label_timespan',
         'label_name',
         'label_type',
         'label'
@@ -116,7 +116,7 @@ def create_entity_date_df(
     as_of_dates = [date.date() for date in as_of_dates]
     labels_table = labels_table[labels_table['label_name'] == label_name]
     labels_table = labels_table[labels_table['label_type'] == label_type]
-    labels_table = labels_table[labels_table['label_window'] == label_window]
+    labels_table = labels_table[labels_table['label_timespan'] == label_timespan]
     labels_table = labels_table.join(
         other=states_table,
         on=('entity_id', 'as_of_date'),


### PR DESCRIPTION
Changes to support the new timechop names in [timechop pr 79](https://github.com/dssg/timechop/pull/79/)

NOTES: 
* tests seem to be passing with some warnings
* still need to bump the pegged dependency versions once they're updated.

See also:
* https://github.com/dssg/metta-data/pull/49
* https://github.com/dssg/catwalk/pull/36
* https://github.com/dssg/triage/pull/242
* https://github.com/dssg/results-schema/issues/11